### PR TITLE
Chore: Enable style check linter

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -32,7 +32,7 @@ enable = [
   "exportloopref",
   "staticcheck",
   "structcheck",
-  #"stylecheck",
+  "stylecheck",
   "typecheck",
   "unconvert",
   "unused",

--- a/admin.go
+++ b/admin.go
@@ -22,7 +22,7 @@ func (c *Client) CreateUser(user User) (int64, error) {
 	}
 
 	created := struct {
-		Id int64 `json:"id"`
+		ID int64 `json:"id"`
 	}{}
 
 	err = c.request("POST", "/api/admin/users", nil, bytes.NewBuffer(data), &created)
@@ -30,7 +30,7 @@ func (c *Client) CreateUser(user User) (int64, error) {
 		return id, err
 	}
 
-	return created.Id, err
+	return created.ID, err
 }
 
 // DeleteUser deletes a Grafana user.

--- a/alertnotification.go
+++ b/alertnotification.go
@@ -8,8 +8,8 @@ import (
 
 // AlertNotification represents a Grafana alert notification.
 type AlertNotification struct {
-	Id                    int64       `json:"id,omitempty"`
-	Uid                   string      `json:"uid"`
+	ID                    int64       `json:"id,omitempty"`
+	UID                   string      `json:"uid"`
 	Name                  string      `json:"name"`
 	Type                  string      `json:"type"`
 	IsDefault             bool        `json:"isDefault"`
@@ -50,7 +50,7 @@ func (c *Client) NewAlertNotification(a *AlertNotification) (int64, error) {
 		return 0, err
 	}
 	result := struct {
-		Id int64 `json:"id"`
+		ID int64 `json:"id"`
 	}{}
 
 	err = c.request("POST", "/api/alert-notifications", nil, bytes.NewBuffer(data), &result)
@@ -58,12 +58,12 @@ func (c *Client) NewAlertNotification(a *AlertNotification) (int64, error) {
 		return 0, err
 	}
 
-	return result.Id, err
+	return result.ID, err
 }
 
 // UpdateAlertNotification updates a Grafana alert notification.
 func (c *Client) UpdateAlertNotification(a *AlertNotification) error {
-	path := fmt.Sprintf("/api/alert-notifications/%d", a.Id)
+	path := fmt.Sprintf("/api/alert-notifications/%d", a.ID)
 	data, err := json.Marshal(a)
 	if err != nil {
 		return err

--- a/alertnotification_test.go
+++ b/alertnotification_test.go
@@ -89,7 +89,7 @@ func TestAlertNotifications(t *testing.T) {
 	if len(alertnotifications) != 1 {
 		t.Error("Length of returned alert notifications should be 1")
 	}
-	if alertnotifications[0].Id != 1 || alertnotifications[0].Name != "Team A" {
+	if alertnotifications[0].ID != 1 || alertnotifications[0].Name != "Team A" {
 		t.Error("Not correctly parsing returned alert notifications.")
 	}
 }
@@ -106,7 +106,7 @@ func TestAlertNotification(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	if resp.Id != alertnotification || resp.Name != "Team A" {
+	if resp.ID != alertnotification || resp.Name != "Team A" {
 		t.Error("Not correctly parsing returned alert notification.")
 	}
 }
@@ -143,7 +143,7 @@ func TestUpdateAlertNotification(t *testing.T) {
 	defer server.Close()
 
 	an := &AlertNotification{
-		Id:                    1,
+		ID:                    1,
 		Name:                  "Team A",
 		Type:                  "email",
 		IsDefault:             false,

--- a/dashboard.go
+++ b/dashboard.go
@@ -17,27 +17,27 @@ type DashboardMeta struct {
 // DashboardSaveResponse represents the Grafana API response to creating or saving a dashboard.
 type DashboardSaveResponse struct {
 	Slug    string `json:"slug"`
-	Id      int64  `json:"id"`
-	Uid     string `json:"uid"`
+	ID      int64  `json:"id"`
+	UID     string `json:"uid"`
 	Status  string `json:"status"`
 	Version int64  `json:"version"`
 }
 
 // DashboardSearchResponse represents the Grafana API dashboard search response.
 type DashboardSearchResponse struct {
-	Id          uint     `json:"id"`
-	Uid         string   `json:"uid"`
+	ID          uint     `json:"id"`
+	UID         string   `json:"uid"`
 	Title       string   `json:"title"`
-	Uri         string   `json:"uri"`
-	Url         string   `json:"url"`
+	URI         string   `json:"uri"`
+	URL         string   `json:"url"`
 	Slug        string   `json:"slug"`
 	Type        string   `json:"type"`
 	Tags        []string `json:"tags"`
 	IsStarred   bool     `json:"isStarred"`
-	FolderId    uint     `json:"folderId"`
-	FolderUid   string   `json:"folderUid"`
+	FolderID    uint     `json:"folderId"`
+	FolderUID   string   `json:"folderUid"`
 	FolderTitle string   `json:"folderTitle"`
-	FolderUrl   string   `json:"folderUrl"`
+	FolderURL   string   `json:"folderUrl"`
 }
 
 // Dashboard represents a Grafana dashboard.
@@ -100,19 +100,13 @@ func (c *Client) Dashboards() ([]DashboardSearchResponse, error) {
 	return dashboards, err
 }
 
-// DashboardByUid fetches and returns the dashboard whose UID is passed.
-func (c *Client) DashboardByUid(uid string) (*Dashboard, error) {
-	return c.dashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
-}
-
 // Dashboard will be removed.
-// Deprecated: Starting from Grafana v5.0. Use DashboardByUid instead.
+// Deprecated: Starting from Grafana v5.0. Use DashboardByUID instead.
 func (c *Client) Dashboard(slug string) (*Dashboard, error) {
 	return c.dashboard(fmt.Sprintf("/api/dashboards/db/%s", slug))
 }
 
-// DashboardByUID will be removed.
-// Deprecated: Interface typo. Use DashboardByUid instead.
+// DashboardByUID gets a dashboard by UID.
 func (c *Client) DashboardByUID(uid string) (*Dashboard, error) {
 	return c.dashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
 }
@@ -128,19 +122,13 @@ func (c *Client) dashboard(path string) (*Dashboard, error) {
 	return result, err
 }
 
-// DeleteDashboardByUid deletes the dashboard whose UID it's passed.
-func (c *Client) DeleteDashboardByUid(uid string) error {
-	return c.deleteDashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
-}
-
 // DeleteDashboard will be removed.
-// Deprecated: Starting from Grafana v5.0. Use DeleteDashboardByUid instead.
+// Deprecated: Starting from Grafana v5.0. Use DeleteDashboardByUID instead.
 func (c *Client) DeleteDashboard(slug string) error {
 	return c.deleteDashboard(fmt.Sprintf("/api/dashboards/db/%s", slug))
 }
 
-// DeleteDashboardByUID will be removed.
-// Deprecated: Interface typo. Use DeleteDashboardByUid instead.
+// DeleteDashboardByUID deletes a dashboard by UID.
 func (c *Client) DeleteDashboardByUID(uid string) error {
 	return c.deleteDashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
 }

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -63,8 +63,8 @@ func TestDashboardCreateAndUpdate(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	if resp.Uid != "nErXDvCkzz" {
-		t.Errorf("Invalid uid - %s, Expected %s", resp.Uid, "nErXDvCkzz")
+	if resp.UID != "nErXDvCkzz" {
+		t.Errorf("Invalid uid - %s, Expected %s", resp.UID, "nErXDvCkzz")
 	}
 
 	for _, code := range []int{400, 401, 403, 412} {
@@ -89,7 +89,7 @@ func TestDashboardGet(t *testing.T) {
 		t.Errorf("Invalid uid - %s, Expected %s", uid, "cIBgcSjkk")
 	}
 
-	resp, err = client.DashboardByUid("cIBgcSjkk")
+	resp, err = client.DashboardByUID("cIBgcSjkk")
 	if err != nil {
 		t.Error(err)
 	}
@@ -105,7 +105,7 @@ func TestDashboardGet(t *testing.T) {
 			t.Errorf("%d not detected", code)
 		}
 
-		_, err = client.DashboardByUid("cIBgcSjkk")
+		_, err = client.DashboardByUID("cIBgcSjkk")
 		if err == nil {
 			t.Errorf("%d not detected", code)
 		}
@@ -121,7 +121,7 @@ func TestDashboardDelete(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = client.DeleteDashboardByUid("cIBgcSjkk")
+	err = client.DeleteDashboardByUID("cIBgcSjkk")
 	if err != nil {
 		t.Error(err)
 	}
@@ -134,7 +134,7 @@ func TestDashboardDelete(t *testing.T) {
 			t.Errorf("%d not detected", code)
 		}
 
-		err = client.DeleteDashboardByUid("cIBgcSjkk")
+		err = client.DeleteDashboardByUID("cIBgcSjkk")
 		if err == nil {
 			t.Errorf("%d not detected", code)
 		}
@@ -156,7 +156,7 @@ func TestDashboards(t *testing.T) {
 		t.Error("Length of returned dashboards should be 1")
 	}
 
-	if dashboards[0].Id != 1 || dashboards[0].Title != "Grafana Stats" {
+	if dashboards[0].ID != 1 || dashboards[0].Title != "Grafana Stats" {
 		t.Error("Not correctly parsing returned dashboards.")
 	}
 }

--- a/datasource.go
+++ b/datasource.go
@@ -8,7 +8,7 @@ import (
 
 // DataSource represents a Grafana data source.
 type DataSource struct {
-	Id     int64  `json:"id,omitempty"`
+	ID     int64  `json:"id,omitempty"`
 	Name   string `json:"name"`
 	Type   string `json:"type"`
 	URL    string `json:"url"`
@@ -19,7 +19,7 @@ type DataSource struct {
 	// Deprecated: Use secureJsonData.password instead.
 	Password string `json:"password,omitempty"`
 
-	OrgId     int64 `json:"orgId,omitempty"`
+	OrgID     int64 `json:"orgId,omitempty"`
 	IsDefault bool  `json:"isDefault"`
 
 	BasicAuth     bool   `json:"basicAuth"`
@@ -34,9 +34,9 @@ type DataSource struct {
 // JSONData is a representation of the datasource `jsonData` property
 type JSONData struct {
 	// Used by all datasources
-	TlsAuth           bool `json:"tlsAuth,omitempty"`
-	TlsAuthWithCACert bool `json:"tlsAuthWithCACert,omitempty"`
-	TlsSkipVerify     bool `json:"tlsSkipVerify,omitempty"`
+	TLSAuth           bool `json:"tlsAuth,omitempty"`
+	TLSAuthWithCACert bool `json:"tlsAuthWithCACert,omitempty"`
+	TLSSkipVerify     bool `json:"tlsSkipVerify,omitempty"`
 
 	// Used by Graphite
 	GraphiteVersion string `json:"graphiteVersion,omitempty"`
@@ -75,22 +75,22 @@ type JSONData struct {
 	ConnMaxLifetime int64 `json:"connMaxLifetime,omitempty"`
 
 	// Used by Prometheus
-	HttpMethod   string `json:"httpMethod,omitempty"`
+	HTTPMethod   string `json:"httpMethod,omitempty"`
 	QueryTimeout string `json:"queryTimeout,omitempty"`
 
 	// Used by Stackdriver
 	AuthenticationType string `json:"authenticationType,omitempty"`
 	ClientEmail        string `json:"clientEmail,omitempty"`
 	DefaultProject     string `json:"defaultProject,omitempty"`
-	TokenUri           string `json:"tokenUri,omitempty"`
+	TokenURI           string `json:"tokenUri,omitempty"`
 }
 
 // SecureJSONData is a representation of the datasource `secureJsonData` property
 type SecureJSONData struct {
 	// Used by all datasources
-	TlsCACert         string `json:"tlsCACert,omitempty"`
-	TlsClientCert     string `json:"tlsClientCert,omitempty"`
-	TlsClientKey      string `json:"tlsClientKey,omitempty"`
+	TLSCACert         string `json:"tlsCACert,omitempty"`
+	TLSClientCert     string `json:"tlsClientCert,omitempty"`
+	TLSClientKey      string `json:"tlsClientKey,omitempty"`
 	Password          string `json:"password,omitempty"`
 	BasicAuthPassword string `json:"basicAuthPassword,omitempty"`
 
@@ -110,7 +110,7 @@ func (c *Client) NewDataSource(s *DataSource) (int64, error) {
 	}
 
 	result := struct {
-		Id int64 `json:"id"`
+		ID int64 `json:"id"`
 	}{}
 
 	err = c.request("POST", "/api/datasources", nil, bytes.NewBuffer(data), &result)
@@ -118,12 +118,12 @@ func (c *Client) NewDataSource(s *DataSource) (int64, error) {
 		return 0, err
 	}
 
-	return result.Id, err
+	return result.ID, err
 }
 
 // UpdateDataSource updates a Grafana data source.
 func (c *Client) UpdateDataSource(s *DataSource) error {
-	path := fmt.Sprintf("/api/datasources/%d", s.Id)
+	path := fmt.Sprintf("/api/datasources/%d", s.ID)
 	data, err := json.Marshal(s)
 	if err != nil {
 		return err

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -25,7 +25,7 @@ func TestNewDataSource(t *testing.T) {
 			AuthType:                "keys",
 			CustomMetricsNamespaces: "SomeNamespace",
 			DefaultRegion:           "us-east-1",
-			TlsSkipVerify:           true,
+			TLSSkipVerify:           true,
 		},
 		SecureJSONData: SecureJSONData{
 			AccessKey: "123",
@@ -56,7 +56,7 @@ func TestNewPrometheusDataSource(t *testing.T) {
 		Access:    "access",
 		IsDefault: true,
 		JSONData: JSONData{
-			HttpMethod:   "POST",
+			HTTPMethod:   "POST",
 			QueryTimeout: "60s",
 			TimeInterval: "1m",
 		},

--- a/folder.go
+++ b/folder.go
@@ -8,8 +8,8 @@ import (
 
 // Folder represents a Grafana folder.
 type Folder struct {
-	Id    int64  `json:"id"`
-	Uid   string `json:"uid"`
+	ID    int64  `json:"id"`
+	UID   string `json:"uid"`
 	Title string `json:"title"`
 }
 

--- a/folder_permissions.go
+++ b/folder_permissions.go
@@ -8,10 +8,10 @@ import (
 
 // FolderPermission has information such as a folder, user, team, role and permission.
 type FolderPermission struct {
-	Id        int64  `json:"id"`
-	FolderUid string `json:"uid"`
-	UserId    int64  `json:"userId"`
-	TeamId    int64  `json:"teamId"`
+	ID        int64  `json:"id"`
+	FolderUID string `json:"uid"`
+	UserID    int64  `json:"userId"`
+	TeamID    int64  `json:"teamId"`
 	Role      string `json:"role"`
 	IsFolder  bool   `json:"isFolder"`
 
@@ -23,8 +23,8 @@ type FolderPermission struct {
 	PermissionName string `json:"permissionName"`
 
 	// optional fields
-	FolderId    int64 `json:"folderId,omitempty"`
-	DashboardId int64 `json:"dashboardId,omitempty"`
+	FolderID    int64 `json:"folderId,omitempty"`
+	DashboardID int64 `json:"dashboardId,omitempty"`
 }
 
 // PermissionItems represents Grafana folder permission items.
@@ -34,11 +34,11 @@ type PermissionItems struct {
 
 // PermissionItem represents a Grafana folder permission item.
 type PermissionItem struct {
-	// As you can see the docs, each item has a pair of [Role|TeamId|UserId] and Permission.
+	// As you can see the docs, each item has a pair of [Role|TeamID|UserID] and Permission.
 	// unnecessary fields are omitted.
 	Role       string `json:"role,omitempty"`
-	TeamId     int64  `json:"teamId,omitempty"`
-	UserId     int64  `json:"userId,omitempty"`
+	TeamID     int64  `json:"teamId,omitempty"`
+	UserID     int64  `json:"userId,omitempty"`
 	Permission int64  `json:"permission"`
 }
 

--- a/folder_permissions_test.go
+++ b/folder_permissions_test.go
@@ -70,34 +70,34 @@ func TestFolderPermissions(t *testing.T) {
 
 	expects := []*FolderPermission{
 		{
-			Id:             1,
-			FolderUid:      "nErXDvCkzz",
-			UserId:         0,
-			TeamId:         0,
+			ID:             1,
+			FolderUID:      "nErXDvCkzz",
+			UserID:         0,
+			TeamID:         0,
 			Role:           "Viewer",
 			IsFolder:       false,
 			Permission:     1,
 			PermissionName: "View",
-			FolderId:       -1,
-			DashboardId:    0,
+			FolderID:       -1,
+			DashboardID:    0,
 		},
 		{
-			Id:             2,
-			FolderUid:      "",
-			UserId:         0,
-			TeamId:         0,
+			ID:             2,
+			FolderUID:      "",
+			UserID:         0,
+			TeamID:         0,
 			Role:           "Editor",
 			IsFolder:       false,
 			Permission:     2,
 			PermissionName: "Edit",
-			FolderId:       0,
-			DashboardId:    -1,
+			FolderID:       0,
+			DashboardID:    -1,
 		},
 	}
 
 	for i, expect := range expects {
 		t.Run("check data", func(t *testing.T) {
-			if resp[i].Id != expect.Id || resp[i].Role != expect.Role {
+			if resp[i].ID != expect.ID || resp[i].Role != expect.Role {
 				t.Error("Not correctly data")
 			}
 		})
@@ -119,11 +119,11 @@ func TestUpdateFolderPermissions(t *testing.T) {
 				Permission: 2,
 			},
 			{
-				TeamId:     1,
+				TeamID:     1,
 				Permission: 1,
 			},
 			{
-				UserId:     11,
+				UserID:     11,
 				Permission: 4,
 			},
 		},

--- a/folder_test.go
+++ b/folder_test.go
@@ -98,7 +98,7 @@ func TestFolders(t *testing.T) {
 	if len(folders) != 1 {
 		t.Error("Length of returned folders should be 1")
 	}
-	if folders[0].Id != 1 || folders[0].Title != "Departmenet ABC" {
+	if folders[0].ID != 1 || folders[0].Title != "Departmenet ABC" {
 		t.Error("Not correctly parsing returned folders.")
 	}
 }
@@ -115,7 +115,7 @@ func TestFolder(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	if resp.Id != folder || resp.Title != "Departmenet ABC" {
+	if resp.ID != folder || resp.Title != "Departmenet ABC" {
 		t.Error("Not correctly parsing returned folder.")
 	}
 }
@@ -131,7 +131,7 @@ func TestNewFolder(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	if resp.Uid != "nErXDvCkzz" {
+	if resp.UID != "nErXDvCkzz" {
 		t.Error("Not correctly parsing returned creation message.")
 	}
 }

--- a/org_users.go
+++ b/org_users.go
@@ -8,8 +8,8 @@ import (
 
 // OrgUser represents a Grafana org user.
 type OrgUser struct {
-	OrgId  int64  `json:"orgId"`
-	UserId int64  `json:"userId"`
+	OrgID  int64  `json:"orgId"`
+	UserID int64  `json:"userId"`
 	Email  string `json:"email"`
 	Login  string `json:"login"`
 	Role   string `json:"role"`

--- a/org_users_test.go
+++ b/org_users_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	getOrgUsersJSON   = `[{"orgId":1,"userId":1,"email":"admin@localhost","avatarUrl":"/avatar/46d229b033af06a191ff2267bca9ae56","login":"admin","role":"Admin","lastSeenAt":"2018-06-28T14:16:11Z","lastSeenAtAge":"\u003c 1m"}]`
+	getOrgUsersJSON   = `[{"orgID":1,"userID":1,"email":"admin@localhost","avatarUrl":"/avatar/46d229b033af06a191ff2267bca9ae56","login":"admin","role":"Admin","lastSeenAt":"2018-06-28T14:16:11Z","lastSeenAtAge":"\u003c 1m"}]`
 	addOrgUserJSON    = `{"message":"User added to organization"}`
 	updateOrgUserJSON = `{"message":"Organization user updated"}`
 	removeOrgUserJSON = `{"message":"User removed from organization"}`
@@ -26,8 +26,8 @@ func TestOrgUsers(t *testing.T) {
 	t.Log(pretty.PrettyFormat(resp))
 
 	user := OrgUser{
-		OrgId:  1,
-		UserId: 1,
+		OrgID:  1,
+		UserID: 1,
 		Email:  "admin@localhost",
 		Login:  "admin",
 		Role:   "Admin",
@@ -42,9 +42,9 @@ func TestAddOrgUser(t *testing.T) {
 	server, client := gapiTestTools(200, addOrgUserJSON)
 	defer server.Close()
 
-	orgId, user, role := int64(1), "admin@localhost", "Admin"
+	orgID, user, role := int64(1), "admin@localhost", "Admin"
 
-	err := client.AddOrgUser(orgId, user, role)
+	err := client.AddOrgUser(orgID, user, role)
 	if err != nil {
 		t.Error(err)
 	}
@@ -54,9 +54,9 @@ func TestUpdateOrgUser(t *testing.T) {
 	server, client := gapiTestTools(200, updateOrgUserJSON)
 	defer server.Close()
 
-	orgId, userId, role := int64(1), int64(1), "Editor"
+	orgID, userID, role := int64(1), int64(1), "Editor"
 
-	err := client.UpdateOrgUser(orgId, userId, role)
+	err := client.UpdateOrgUser(orgID, userID, role)
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,9 +66,9 @@ func TestRemoveOrgUser(t *testing.T) {
 	server, client := gapiTestTools(200, removeOrgUserJSON)
 	defer server.Close()
 
-	orgId, userId := int64(1), int64(1)
+	orgID, userID := int64(1), int64(1)
 
-	err := client.RemoveOrgUser(orgId, userId)
+	err := client.RemoveOrgUser(orgID, userID)
 	if err != nil {
 		t.Error(err)
 	}

--- a/orgs.go
+++ b/orgs.go
@@ -8,7 +8,7 @@ import (
 
 // Org represents a Grafana org.
 type Org struct {
-	Id   int64  `json:"id"`
+	ID   int64  `json:"id"`
 	Name string `json:"name"`
 }
 
@@ -57,7 +57,7 @@ func (c *Client) NewOrg(name string) (int64, error) {
 		return id, err
 	}
 	tmp := struct {
-		Id int64 `json:"orgId"`
+		ID int64 `json:"orgId"`
 	}{}
 
 	err = c.request("POST", "/api/orgs", nil, bytes.NewBuffer(data), &tmp)
@@ -65,7 +65,7 @@ func (c *Client) NewOrg(name string) (int64, error) {
 		return id, err
 	}
 
-	return tmp.Id, err
+	return tmp.ID, err
 }
 
 // UpdateOrg updates a Grafana org.

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -28,7 +28,7 @@ func TestOrgs(t *testing.T) {
 	if len(orgs) != 2 {
 		t.Error("Length of returned orgs should be 2")
 	}
-	if orgs[0].Id != 1 || orgs[0].Name != "Main Org." {
+	if orgs[0].ID != 1 || orgs[0].Name != "Main Org." {
 		t.Error("Not correctly parsing returned organizations.")
 	}
 }
@@ -45,7 +45,7 @@ func TestOrgByName(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	if resp.Id != 1 || resp.Name != org {
+	if resp.ID != 1 || resp.Name != org {
 		t.Error("Not correctly parsing returned organization.")
 	}
 }
@@ -62,7 +62,7 @@ func TestOrg(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	if resp.Id != org || resp.Name != "Main Org." {
+	if resp.ID != org || resp.Name != "Main Org." {
 		t.Error("Not correctly parsing returned organization.")
 	}
 }

--- a/playlist.go
+++ b/playlist.go
@@ -16,7 +16,7 @@ type PlaylistItem struct {
 
 // Playlist represents a Grafana playlist.
 type Playlist struct {
-	Id       int            `json:"id"`
+	ID       int            `json:"id"`
 	Name     string         `json:"name"`
 	Interval string         `json:"interval"`
 	Items    []PlaylistItem `json:"items"`
@@ -42,7 +42,7 @@ func (c *Client) NewPlaylist(playlist Playlist) (int, error) {
 	}
 
 	result := struct {
-		Id int
+		ID int
 	}{}
 
 	err = c.request("POST", "/api/playlists", nil, bytes.NewBuffer(data), &result)
@@ -50,12 +50,12 @@ func (c *Client) NewPlaylist(playlist Playlist) (int, error) {
 		return 0, err
 	}
 
-	return result.Id, nil
+	return result.ID, nil
 }
 
 // UpdatePlaylist updates a Grafana playlist.
 func (c *Client) UpdatePlaylist(playlist Playlist) error {
-	path := fmt.Sprintf("/api/playlists/%d", playlist.Id)
+	path := fmt.Sprintf("/api/playlists/%d", playlist.ID)
 	data, err := json.Marshal(playlist)
 	if err != nil {
 		return err

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -82,8 +82,8 @@ func TestGetPlaylist(t *testing.T) {
 		t.Error(err)
 	}
 
-	if playlist.Id != 2 {
-		t.Errorf("Invalid id - %d, Expected %d", playlist.Id, 1)
+	if playlist.ID != 2 {
+		t.Errorf("Invalid id - %d, Expected %d", playlist.ID, 1)
 	}
 
 	if len(playlist.Items) != 2 {

--- a/team.go
+++ b/team.go
@@ -18,30 +18,30 @@ type SearchTeam struct {
 // Team consists of a get response
 // It's used in  Add and Update API
 type Team struct {
-	Id          int64  `json:"id,omitempty"`
-	OrgId       int64  `json:"orgId,omitempty"`
+	ID          int64  `json:"id,omitempty"`
+	OrgID       int64  `json:"orgId,omitempty"`
 	Name        string `json:"name"`
 	Email       string `json:"email,omitempty"`
-	AvatarUrl   string `json:"avatarUrl,omitempty"`
+	AvatarURL   string `json:"avatarUrl,omitempty"`
 	MemberCount int64  `json:"memberCount,omitempty"`
 	Permission  int64  `json:"permission,omitempty"`
 }
 
 // TeamMember represents a Grafana team member.
 type TeamMember struct {
-	OrgId      int64  `json:"orgId,omitempty"`
-	TeamId     int64  `json:"teamId,omitempty"`
-	UserId     int64  `json:"userId,omitempty"`
+	OrgID      int64  `json:"orgId,omitempty"`
+	TeamID     int64  `json:"teamId,omitempty"`
+	UserID     int64  `json:"userID,omitempty"`
 	Email      string `json:"email,omitempty"`
 	Login      string `json:"login,omitempty"`
-	AvatarUrl  string `json:"avatarUrl,omitempty"`
+	AvatarURL  string `json:"avatarUrl,omitempty"`
 	Permission int64  `json:"permission,omitempty"`
 }
 
 // Preferences represents Grafana preferences.
 type Preferences struct {
 	Theme           string `json:"theme"`
-	HomeDashboardId int64  `json:"homeDashboardId"`
+	HomeDashboardID int64  `json:"homeDashboardID"`
 	Timezone        string `json:"timezone"`
 }
 
@@ -141,7 +141,7 @@ func (c *Client) TeamMembers(id int64) ([]*TeamMember, error) {
 // AddTeamMember adds a user to the Grafana team whose ID it's passed.
 func (c *Client) AddTeamMember(id int64, userID int64) error {
 	path := fmt.Sprintf("/api/teams/%d/members", id)
-	member := TeamMember{UserId: userID}
+	member := TeamMember{UserID: userID}
 	data, err := json.Marshal(member)
 	if err != nil {
 		return err
@@ -173,7 +173,7 @@ func (c *Client) UpdateTeamPreferences(id int64, theme string, homeDashboardID i
 	path := fmt.Sprintf("/api/teams/%d", id)
 	preferences := Preferences{
 		Theme:           theme,
-		HomeDashboardId: homeDashboardID,
+		HomeDashboardID: homeDashboardID,
 		Timezone:        timezone,
 	}
 	data, err := json.Marshal(preferences)

--- a/teams_test.go
+++ b/teams_test.go
@@ -48,7 +48,7 @@ const (
   {
     "orgId": 1,
     "teamId": 1,
-    "userId": 3,
+    "userID": 3,
     "auth_module": "oauth_github",
     "email": "user1@email.com",
     "login": "user1",
@@ -59,7 +59,7 @@ const (
   {
     "orgId": 1,
     "teamId": 1,
-    "userId": 2,
+    "userID": 2,
     "auth_module": "oauth_github",
     "email": "user2@email.com",
     "login": "user2",
@@ -71,14 +71,14 @@ const (
 `
 	addTeamMemberJSON = `
 {
-  "userId": 2
+  "userID": 2
 }
 `
 	removeMemberFromTeamJSON = `{"message":"Team Member removed"}`
 	getTeamPreferencesJSON   = `
 {
   "theme": "",
-  "homeDashboardId": 0,
+  "homeDashboardID": 0,
   "timezone": ""
 }
 `
@@ -105,11 +105,11 @@ func TestSearchTeam(t *testing.T) {
 		TotalCount: 1,
 		Teams: []*Team{
 			{
-				Id:          1,
-				OrgId:       1,
+				ID:          1,
+				OrgID:       1,
 				Name:        "MyTestTeam",
 				Email:       "",
-				AvatarUrl:   "avatar/3f49c15916554246daa714b9bd0ee398",
+				AvatarURL:   "avatar/3f49c15916554246daa714b9bd0ee398",
 				MemberCount: 1,
 				Permission:  0,
 			},
@@ -137,16 +137,16 @@ func TestTeam(t *testing.T) {
 	t.Log(pretty.PrettyFormat(resp))
 
 	expect := &Team{
-		Id:          1,
-		OrgId:       1,
+		ID:          1,
+		OrgID:       1,
 		Name:        "MyTestTeam",
 		Email:       "",
-		AvatarUrl:   "avatar/abcdef",
+		AvatarURL:   "avatar/abcdef",
 		MemberCount: 1,
 		Permission:  0,
 	}
 	t.Run("check data", func(t *testing.T) {
-		if resp.Id != expect.Id || resp.Name != expect.Name {
+		if resp.ID != expect.ID || resp.Name != expect.Name {
 			t.Error("Not correctly parsing returned team.")
 		}
 	})
@@ -206,28 +206,28 @@ func TestTeamMembers(t *testing.T) {
 	}
 	expects := []*TeamMember{
 		{
-			OrgId:      1,
-			TeamId:     1,
-			UserId:     3,
+			OrgID:      1,
+			TeamID:     1,
+			UserID:     3,
 			Email:      "user1@email.com",
 			Login:      "user1",
-			AvatarUrl:  "/avatar/1b3c32f6386b0185c40d359cdc733a79",
+			AvatarURL:  "/avatar/1b3c32f6386b0185c40d359cdc733a79",
 			Permission: 0,
 		},
 		{
-			OrgId:      1,
-			TeamId:     1,
-			UserId:     2,
+			OrgID:      1,
+			TeamID:     1,
+			UserID:     2,
 			Email:      "user2@email.com",
 			Login:      "user2",
-			AvatarUrl:  "/avatar/cad3c68da76e45d10269e8ef02f8e73e",
+			AvatarURL:  "/avatar/cad3c68da76e45d10269e8ef02f8e73e",
 			Permission: 0,
 		},
 	}
 
 	for i, expect := range expects {
 		t.Run("check data", func(t *testing.T) {
-			if expect.Email != resp[i].Email || expect.AvatarUrl != resp[i].AvatarUrl {
+			if expect.Email != resp[i].Email || expect.AvatarURL != resp[i].AvatarURL {
 				t.Error("Not correctly parsing returned team members.")
 			}
 		})
@@ -239,9 +239,9 @@ func TestAddTeamMember(t *testing.T) {
 	defer server.Close()
 
 	id := int64(1)
-	userId := int64(2)
+	userID := int64(2)
 
-	if err := client.AddTeamMember(id, userId); err != nil {
+	if err := client.AddTeamMember(id, userID); err != nil {
 		t.Error(err)
 	}
 }
@@ -251,9 +251,9 @@ func TestRemoveMemberFromTeam(t *testing.T) {
 	defer server.Close()
 
 	id := int64(1)
-	userId := int64(2)
+	userID := int64(2)
 
-	if err := client.RemoveMemberFromTeam(id, userId); err != nil {
+	if err := client.RemoveMemberFromTeam(id, userID); err != nil {
 		t.Error(err)
 	}
 }
@@ -270,12 +270,12 @@ func TestTeamPreferences(t *testing.T) {
 	}
 	expect := &Preferences{
 		Theme:           "",
-		HomeDashboardId: 0,
+		HomeDashboardID: 0,
 		Timezone:        "",
 	}
 
 	t.Run("check data", func(t *testing.T) {
-		if expect.Theme != resp.Theme || expect.HomeDashboardId != resp.HomeDashboardId {
+		if expect.Theme != resp.Theme || expect.HomeDashboardID != resp.HomeDashboardID {
 			t.Error("Not correctly parsing returned team preferences.")
 		}
 	})
@@ -287,10 +287,10 @@ func TestUpdateTeamPreferences(t *testing.T) {
 
 	id := int64(1)
 	theme := ""
-	homeDashboardId := int64(0)
+	homeDashboardID := int64(0)
 	timezone := ""
 
-	if err := client.UpdateTeamPreferences(id, theme, homeDashboardId, timezone); err != nil {
+	if err := client.UpdateTeamPreferences(id, theme, homeDashboardID, timezone); err != nil {
 		t.Error(err)
 	}
 }

--- a/user.go
+++ b/user.go
@@ -11,19 +11,19 @@ import (
 // User represents a Grafana user. It is structured after the UserProfileDTO
 // struct in the Grafana codebase.
 type User struct {
-	Id         int64     `json:"id,omitempty"`
+	ID         int64     `json:"id,omitempty"`
 	Email      string    `json:"email,omitempty"`
 	Name       string    `json:"name,omitempty"`
 	Login      string    `json:"login,omitempty"`
 	Theme      string    `json:"theme,omitempty"`
-	OrgId      int64     `json:"orgId,omitempty"`
+	OrgID      int64     `json:"orgId,omitempty"`
 	IsAdmin    bool      `json:"isGrafanaAdmin,omitempty"`
 	IsDisabled bool      `json:"isDisabled,omitempty"`
 	IsExternal bool      `json:"isExternal,omitempty"`
 	UpdatedAt  time.Time `json:"updatedAt,omitempty"`
 	CreatedAt  time.Time `json:"createdAt,omitempty"`
 	AuthLabels []string  `json:"authLabels,omitempty"`
-	AvatarUrl  string    `json:"avatarUrl,omitempty"`
+	AvatarURL  string    `json:"avatarUrl,omitempty"`
 	Password   string    `json:"password,omitempty"`
 }
 
@@ -32,7 +32,7 @@ type User struct {
 // reduced and differing fields. It is structured after the UserSearchHitDTO
 // struct in the Grafana codebase.
 type UserSearch struct {
-	Id            int64     `json:"id,omitempty"`
+	ID            int64     `json:"id,omitempty"`
 	Email         string    `json:"email,omitempty"`
 	Name          string    `json:"name,omitempty"`
 	Login         string    `json:"login,omitempty"`
@@ -41,7 +41,7 @@ type UserSearch struct {
 	LastSeenAt    time.Time `json:"lastSeenAt,omitempty"`
 	LastSeenAtAge string    `json:"lastSeenAtAge,omitempty"`
 	AuthLabels    []string  `json:"authLabels,omitempty"`
-	AvatarUrl     string    `json:"avatarUrl,omitempty"`
+	AvatarURL     string    `json:"avatarUrl,omitempty"`
 }
 
 // Users fetches and returns Grafana users.
@@ -70,5 +70,5 @@ func (c *Client) UserUpdate(u User) error {
 	if err != nil {
 		return err
 	}
-	return c.request("PUT", fmt.Sprintf("/api/users/%d", u.Id), nil, bytes.NewBuffer(data), nil)
+	return c.request("PUT", fmt.Sprintf("/api/users/%d", u.ID), nil, bytes.NewBuffer(data), nil)
 }

--- a/user_test.go
+++ b/user_test.go
@@ -31,7 +31,7 @@ func TestUsers(t *testing.T) {
 	user := resp[0]
 
 	if user.Email != "users@localhost" ||
-		user.Id != 1 ||
+		user.ID != 1 ||
 		user.IsAdmin != true {
 		t.Error("Not correctly parsing returned users.")
 	}
@@ -49,7 +49,7 @@ func TestUser(t *testing.T) {
 	t.Log(pretty.PrettyFormat(user))
 
 	if user.Email != "user@localhost" ||
-		user.Id != 2 ||
+		user.ID != 2 ||
 		user.IsAdmin != false {
 		t.Error("Not correctly parsing returned user.")
 	}
@@ -67,7 +67,7 @@ func TestUserByEmail(t *testing.T) {
 	t.Log(pretty.PrettyFormat(user))
 
 	if user.Email != "userByEmail@localhost" ||
-		user.Id != 3 ||
+		user.ID != 3 ||
 		user.IsAdmin != true {
 		t.Error("Not correctly parsing returned user.")
 	}


### PR DESCRIPTION
Enable style check linter and fix up code to use the standard casing for [initialisms](https://github.com/golang/go/wiki/CodeReviewComments#initialisms).

It looks as if the old code wasn't following the standard style, but we should be consistent, and might as well follow the standard style, which is what the linter enforces.