### PR TITLE
Add organization ID to client connection using header

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/hashicorp/go-cleanhttp"
 )
@@ -31,7 +32,7 @@ type Config struct {
 	// Client provides an optional HTTP client, otherwise a default will be used.
 	Client *http.Client
 	// OrgID provides an optional organization ID, ignored when using APIKey, BasicAuth defaults to last used org
-	OrgID string
+	OrgID int64
 }
 
 // New creates a new Grafana client.
@@ -105,8 +106,8 @@ func (c *Client) newRequest(method, requestPath string, query url.Values, body i
 
 	if c.config.APIKey != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.config.APIKey))
-	} else if c.config.OrgID != "" {
-		req.Header.Add("X-Grafana-Org-Id", c.config.OrgID)
+	} else if c.config.OrgID != 0 {
+		req.Header.Add("X-Grafana-Org-Id", strconv.FormatInt(c.config.OrgID, 10))
 	}
 
 	if os.Getenv("GF_LOG") != "" {

--- a/client.go
+++ b/client.go
@@ -30,6 +30,8 @@ type Config struct {
 	BasicAuth *url.Userinfo
 	// Client provides an optional HTTP client, otherwise a default will be used.
 	Client *http.Client
+	// OrgID provides an optional organization ID, ignored when using APIKey, BasicAuth defaults to last used org
+	OrgID string
 }
 
 // New creates a new Grafana client.
@@ -103,6 +105,8 @@ func (c *Client) newRequest(method, requestPath string, query url.Values, body i
 
 	if c.config.APIKey != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.config.APIKey))
+	} else if c.config.OrgID != "" {
+		req.Header.Add("X-Grafana-Org-Id", c.config.OrgID)
 	}
 
 	if os.Getenv("GF_LOG") != "" {

--- a/client_test.go
+++ b/client_test.go
@@ -36,7 +36,7 @@ func TestNew_tokenAuth(t *testing.T) {
 	}
 }
 
-func TestNew_orgId(t *testing.T) {
+func TestNew_orgID(t *testing.T) {
 	const orgID = 456
 	c, err := New("http://my-grafana.com", Config{OrgID: orgID})
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -37,7 +37,7 @@ func TestNew_tokenAuth(t *testing.T) {
 }
 
 func TestNew_orgId(t *testing.T) {
-	const orgID = "456"
+	const orgID = 456
 	c, err := New("http://my-grafana.com", Config{OrgID: orgID})
 	if err != nil {
 		t.Fatalf("expected error to be nil; got: %s", err.Error())
@@ -49,7 +49,7 @@ func TestNew_orgId(t *testing.T) {
 	}
 
 	if c.config.OrgID != orgID {
-		t.Errorf("expected error: %s; got: %s", orgID, c.config.OrgID)
+		t.Errorf("expected error: %d; got: %d", orgID, c.config.OrgID)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -36,6 +36,23 @@ func TestNew_tokenAuth(t *testing.T) {
 	}
 }
 
+func TestNew_orgId(t *testing.T) {
+	const orgID = "456"
+	c, err := New("http://my-grafana.com", Config{OrgID: orgID})
+	if err != nil {
+		t.Fatalf("expected error to be nil; got: %s", err.Error())
+	}
+
+	expected := "http://my-grafana.com"
+	if c.baseURL.String() != expected {
+		t.Errorf("expected error: %s; got: %s", expected, c.baseURL.String())
+	}
+
+	if c.config.OrgID != orgID {
+		t.Errorf("expected error: %s; got: %s", orgID, c.config.OrgID)
+	}
+}
+
 func TestNew_invalidURL(t *testing.T) {
 	_, err := New("://my-grafana.com", Config{APIKey: "123"})
 


### PR DESCRIPTION
This seems like the right place to do so - the resource API calls that require an organization ID that are not-quite RESTful also would need authentication with a user that is an administrator for the organization.  So putting it in at this level works out, and also avoids adding orgID parameters all over the place.

Co-authored-by: hansnqyr <luke@nqyr.io>

This change was previously submitted to https://github.com/nytm/go-grafana-api/pull/62
It is a prerequisite for this PR: https://github.com/grafana/terraform-provider-grafana/pull/110