### PR TITLE
Client: Re-design New

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -21,7 +21,7 @@ const (
 )
 
 func TestCreateUser(t *testing.T) {
-	server, client := gapiTestTools(200, createUserJSON)
+	server, client := gapiTestTools(t, 200, createUserJSON)
 	defer server.Close()
 	user := User{
 		Email:    "admin@localhost",
@@ -40,7 +40,7 @@ func TestCreateUser(t *testing.T) {
 }
 
 func TestDeleteUser(t *testing.T) {
-	server, client := gapiTestTools(200, deleteUserJSON)
+	server, client := gapiTestTools(t, 200, deleteUserJSON)
 	defer server.Close()
 
 	err := client.DeleteUser(int64(1))
@@ -50,7 +50,7 @@ func TestDeleteUser(t *testing.T) {
 }
 
 func TestUpdateUserPassword(t *testing.T) {
-	server, client := gapiTestTools(200, updateUserPasswordJSON)
+	server, client := gapiTestTools(t, 200, updateUserPasswordJSON)
 	defer server.Close()
 
 	err := client.UpdateUserPassword(int64(1), "new-password")
@@ -60,7 +60,7 @@ func TestUpdateUserPassword(t *testing.T) {
 }
 
 func TestUpdateUserPermissions(t *testing.T) {
-	server, client := gapiTestTools(200, updateUserPermissionsJSON)
+	server, client := gapiTestTools(t, 200, updateUserPermissionsJSON)
 	defer server.Close()
 
 	err := client.UpdateUserPermissions(int64(1), false)
@@ -70,7 +70,7 @@ func TestUpdateUserPermissions(t *testing.T) {
 }
 
 func TestPauseAllAlerts(t *testing.T) {
-	server, client := gapiTestTools(200, pauseAllAlertsJSON)
+	server, client := gapiTestTools(t, 200, pauseAllAlertsJSON)
 	defer server.Close()
 
 	res, err := client.PauseAllAlerts()
@@ -86,7 +86,7 @@ func TestPauseAllAlerts(t *testing.T) {
 }
 
 func TestPauseAllAlerts_500(t *testing.T) {
-	server, client := gapiTestTools(500, pauseAllAlertsJSON)
+	server, client := gapiTestTools(t, 500, pauseAllAlertsJSON)
 	defer server.Close()
 
 	_, err := client.PauseAllAlerts()

--- a/alert_test.go
+++ b/alert_test.go
@@ -47,7 +47,7 @@ const (
 )
 
 func TestAlerts(t *testing.T) {
-	server, client := gapiTestTools(200, alertsJSON)
+	server, client := gapiTestTools(t, 200, alertsJSON)
 	defer server.Close()
 
 	params := url.Values{}
@@ -66,7 +66,7 @@ func TestAlerts(t *testing.T) {
 }
 
 func TestAlerts_500(t *testing.T) {
-	server, client := gapiTestTools(500, alertsJSON)
+	server, client := gapiTestTools(t, 500, alertsJSON)
 	defer server.Close()
 
 	params := url.Values{}
@@ -79,7 +79,7 @@ func TestAlerts_500(t *testing.T) {
 }
 
 func TestAlert(t *testing.T) {
-	server, client := gapiTestTools(200, alertJSON)
+	server, client := gapiTestTools(t, 200, alertJSON)
 	defer server.Close()
 
 	res, err := client.Alert(1)
@@ -95,7 +95,7 @@ func TestAlert(t *testing.T) {
 }
 
 func TestAlert_500(t *testing.T) {
-	server, client := gapiTestTools(500, alertJSON)
+	server, client := gapiTestTools(t, 500, alertJSON)
 	defer server.Close()
 
 	_, err := client.Alert(1)
@@ -105,7 +105,7 @@ func TestAlert_500(t *testing.T) {
 }
 
 func TestPauseAlert(t *testing.T) {
-	server, client := gapiTestTools(200, pauseAlertJSON)
+	server, client := gapiTestTools(t, 200, pauseAlertJSON)
 	defer server.Close()
 
 	res, err := client.PauseAlert(1)
@@ -121,7 +121,7 @@ func TestPauseAlert(t *testing.T) {
 }
 
 func TestPauseAlert_500(t *testing.T) {
-	server, client := gapiTestTools(500, pauseAlertJSON)
+	server, client := gapiTestTools(t, 500, pauseAlertJSON)
 	defer server.Close()
 
 	_, err := client.PauseAlert(1)

--- a/alertnotification_test.go
+++ b/alertnotification_test.go
@@ -76,7 +76,7 @@ const (
 )
 
 func TestAlertNotifications(t *testing.T) {
-	server, client := gapiTestTools(200, getAlertNotificationsJSON)
+	server, client := gapiTestTools(t, 200, getAlertNotificationsJSON)
 	defer server.Close()
 
 	alertnotifications, err := client.AlertNotifications()
@@ -95,13 +95,13 @@ func TestAlertNotifications(t *testing.T) {
 }
 
 func TestAlertNotification(t *testing.T) {
-	server, client := gapiTestTools(200, getAlertNotificationJSON)
+	server, client := gapiTestTools(t, 200, getAlertNotificationJSON)
 	defer server.Close()
 
 	alertnotification := int64(1)
 	resp, err := client.AlertNotification(alertnotification)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -112,7 +112,7 @@ func TestAlertNotification(t *testing.T) {
 }
 
 func TestNewAlertNotification(t *testing.T) {
-	server, client := gapiTestTools(200, createdAlertNotificationJSON)
+	server, client := gapiTestTools(t, 200, createdAlertNotificationJSON)
 	defer server.Close()
 
 	an := &AlertNotification{
@@ -128,7 +128,7 @@ func TestNewAlertNotification(t *testing.T) {
 	}
 	resp, err := client.NewAlertNotification(an)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -139,7 +139,7 @@ func TestNewAlertNotification(t *testing.T) {
 }
 
 func TestUpdateAlertNotification(t *testing.T) {
-	server, client := gapiTestTools(200, updatedAlertNotificationJSON)
+	server, client := gapiTestTools(t, 200, updatedAlertNotificationJSON)
 	defer server.Close()
 
 	an := &AlertNotification{
@@ -162,7 +162,7 @@ func TestUpdateAlertNotification(t *testing.T) {
 }
 
 func TestDeleteAlertNotification(t *testing.T) {
-	server, client := gapiTestTools(200, deletedAlertNotificationJSON)
+	server, client := gapiTestTools(t, 200, deletedAlertNotificationJSON)
 	defer server.Close()
 
 	err := client.DeleteAlertNotification(1)

--- a/annotation_test.go
+++ b/annotation_test.go
@@ -48,7 +48,7 @@ const (
 )
 
 func TestAnnotations(t *testing.T) {
-	server, client := gapiTestTools(200, annotationsJSON)
+	server, client := gapiTestTools(t, 200, annotationsJSON)
 	defer server.Close()
 
 	params := url.Values{}
@@ -58,7 +58,7 @@ func TestAnnotations(t *testing.T) {
 
 	as, err := client.Annotations(params)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(as))
@@ -69,7 +69,7 @@ func TestAnnotations(t *testing.T) {
 }
 
 func TestNewAnnotation(t *testing.T) {
-	server, client := gapiTestTools(200, newAnnotationJSON)
+	server, client := gapiTestTools(t, 200, newAnnotationJSON)
 	defer server.Close()
 
 	a := Annotation{
@@ -83,7 +83,7 @@ func TestNewAnnotation(t *testing.T) {
 	}
 	res, err := client.NewAnnotation(&a)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(res))
@@ -94,7 +94,7 @@ func TestNewAnnotation(t *testing.T) {
 }
 
 func TestUpdateAnnotation(t *testing.T) {
-	server, client := gapiTestTools(200, updateAnnotationJSON)
+	server, client := gapiTestTools(t, 200, updateAnnotationJSON)
 	defer server.Close()
 
 	a := Annotation{
@@ -102,7 +102,7 @@ func TestUpdateAnnotation(t *testing.T) {
 	}
 	res, err := client.UpdateAnnotation(1, &a)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(res))
@@ -113,7 +113,7 @@ func TestUpdateAnnotation(t *testing.T) {
 }
 
 func TestPatchAnnotation(t *testing.T) {
-	server, client := gapiTestTools(200, patchAnnotationJSON)
+	server, client := gapiTestTools(t, 200, patchAnnotationJSON)
 	defer server.Close()
 
 	a := Annotation{
@@ -121,7 +121,7 @@ func TestPatchAnnotation(t *testing.T) {
 	}
 	res, err := client.PatchAnnotation(1, &a)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(res))
@@ -132,7 +132,7 @@ func TestPatchAnnotation(t *testing.T) {
 }
 
 func TestNewGraphiteAnnotation(t *testing.T) {
-	server, client := gapiTestTools(200, newGraphiteAnnotationJSON)
+	server, client := gapiTestTools(t, 200, newGraphiteAnnotationJSON)
 	defer server.Close()
 
 	a := GraphiteAnnotation{
@@ -143,7 +143,7 @@ func TestNewGraphiteAnnotation(t *testing.T) {
 	}
 	res, err := client.NewGraphiteAnnotation(&a)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(res))
@@ -154,12 +154,12 @@ func TestNewGraphiteAnnotation(t *testing.T) {
 }
 
 func TestDeleteAnnotation(t *testing.T) {
-	server, client := gapiTestTools(200, deleteAnnotationJSON)
+	server, client := gapiTestTools(t, 200, deleteAnnotationJSON)
 	defer server.Close()
 
 	res, err := client.DeleteAnnotation(1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(res))
@@ -170,12 +170,12 @@ func TestDeleteAnnotation(t *testing.T) {
 }
 
 func TestDeleteAnnotationByRegionID(t *testing.T) {
-	server, client := gapiTestTools(200, deleteAnnotationJSON)
+	server, client := gapiTestTools(t, 200, deleteAnnotationJSON)
 	defer server.Close()
 
 	res, err := client.DeleteAnnotationByRegionID(1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(res))

--- a/client.go
+++ b/client.go
@@ -11,36 +11,48 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/hashicorp/go-cleanhttp"
 )
 
 // Client is a Grafana API client.
 type Client struct {
-	key     string
+	Config
+
 	baseURL url.URL
-	*http.Client
+	client  *http.Client
 }
 
-// New creates a new grafana client.
-// auth can be in user:pass format, or it can be an api key
-func New(auth, baseURL string) (*Client, error) {
+// Config contains client configuration.
+type Config struct {
+	// APIKey is an optional API key.
+	APIKey string
+	// BasicAuth is optional basic auth credentials.
+	BasicAuth *url.Userinfo
+	// Client provides an optional HTTP client, otherwise a default will be used.
+	Client *http.Client
+}
+
+// New creates a new Grafana client.
+func New(baseURL string, cfg Config) (*Client, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
 	}
-	key := ""
-	if strings.Contains(auth, ":") {
-		split := strings.SplitN(auth, ":", 2)
-		u.User = url.UserPassword(split[0], split[1])
-	} else if auth != "" {
-		key = fmt.Sprintf("Bearer %s", auth)
+
+	if cfg.BasicAuth != nil {
+		u.User = cfg.BasicAuth
 	}
+
+	cli := cfg.Client
+	if cli == nil {
+		cli = cleanhttp.DefaultClient()
+	}
+
 	return &Client{
-		key,
-		*u,
-		cleanhttp.DefaultClient(),
+		Config:  cfg,
+		baseURL: *u,
+		client:  cli,
 	}, nil
 }
 
@@ -50,7 +62,7 @@ func (c *Client) request(method, requestPath string, query url.Values, body io.R
 		return err
 	}
 
-	resp, err := c.Do(r)
+	resp, err := c.client.Do(r)
 	if err != nil {
 		return err
 	}
@@ -89,8 +101,9 @@ func (c *Client) newRequest(method, requestPath string, query url.Values, body i
 	if err != nil {
 		return req, err
 	}
-	if c.key != "" {
-		req.Header.Add("Authorization", c.key)
+
+	if c.Config.APIKey != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.APIKey))
 	}
 
 	if os.Getenv("GF_LOG") != "" {

--- a/client.go
+++ b/client.go
@@ -17,8 +17,7 @@ import (
 
 // Client is a Grafana API client.
 type Client struct {
-	Config
-
+	config  Config
 	baseURL url.URL
 	client  *http.Client
 }
@@ -50,7 +49,7 @@ func New(baseURL string, cfg Config) (*Client, error) {
 	}
 
 	return &Client{
-		Config:  cfg,
+		config:  cfg,
 		baseURL: *u,
 		client:  cli,
 	}, nil
@@ -102,8 +101,8 @@ func (c *Client) newRequest(method, requestPath string, query url.Values, body i
 		return req, err
 	}
 
-	if c.Config.APIKey != "" {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.APIKey))
+	if c.config.APIKey != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.config.APIKey))
 	}
 
 	if os.Getenv("GF_LOG") != "" {

--- a/client_test.go
+++ b/client_test.go
@@ -31,8 +31,8 @@ func TestNew_tokenAuth(t *testing.T) {
 		t.Errorf("expected error: %s; got: %s", expected, c.baseURL.String())
 	}
 
-	if c.Config.APIKey != apiKey {
-		t.Errorf("expected error: %s; got: %s", apiKey, c.Config.APIKey)
+	if c.config.APIKey != apiKey {
+		t.Errorf("expected error: %s; got: %s", apiKey, c.config.APIKey)
 	}
 }
 

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -45,7 +45,7 @@ const (
 )
 
 func TestDashboardCreateAndUpdate(t *testing.T) {
-	server, client := gapiTestTools(200, createdAndUpdateDashboardResponse)
+	server, client := gapiTestTools(t, 200, createdAndUpdateDashboardResponse)
 	defer server.Close()
 
 	dashboard := Dashboard{
@@ -77,7 +77,7 @@ func TestDashboardCreateAndUpdate(t *testing.T) {
 }
 
 func TestDashboardGet(t *testing.T) {
-	server, client := gapiTestTools(200, getDashboardResponse)
+	server, client := gapiTestTools(t, 200, getDashboardResponse)
 	defer server.Close()
 
 	resp, err := client.Dashboard("test")
@@ -91,11 +91,11 @@ func TestDashboardGet(t *testing.T) {
 
 	resp, err = client.DashboardByUID("cIBgcSjkk")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	uid, ok = resp.Model["uid"]
 	if !ok || uid != "cIBgcSjkk" {
-		t.Errorf("Invalid uid - %s, Expected %s", uid, "cIBgcSjkk")
+		t.Fatalf("Invalid UID - %s, Expected %s", uid, "cIBgcSjkk")
 	}
 
 	for _, code := range []int{401, 403, 404} {
@@ -113,7 +113,7 @@ func TestDashboardGet(t *testing.T) {
 }
 
 func TestDashboardDelete(t *testing.T) {
-	server, client := gapiTestTools(200, "")
+	server, client := gapiTestTools(t, 200, "")
 	defer server.Close()
 
 	err := client.DeleteDashboard("test")
@@ -123,7 +123,7 @@ func TestDashboardDelete(t *testing.T) {
 
 	err = client.DeleteDashboardByUID("cIBgcSjkk")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	for _, code := range []int{401, 403, 404, 412} {
@@ -142,12 +142,12 @@ func TestDashboardDelete(t *testing.T) {
 }
 
 func TestDashboards(t *testing.T) {
-	server, client := gapiTestTools(200, getDashboardsJSON)
+	server, client := gapiTestTools(t, 200, getDashboardsJSON)
 	defer server.Close()
 
 	dashboards, err := client.Dashboards()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(dashboards))

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -11,7 +11,7 @@ const (
 )
 
 func TestNewDataSource(t *testing.T) {
-	server, client := gapiTestTools(200, createdDataSourceJSON)
+	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
 	defer server.Close()
 
 	ds := &DataSource{
@@ -35,7 +35,7 @@ func TestNewDataSource(t *testing.T) {
 
 	created, err := client.NewDataSource(ds)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(created))
@@ -46,7 +46,7 @@ func TestNewDataSource(t *testing.T) {
 }
 
 func TestNewPrometheusDataSource(t *testing.T) {
-	server, client := gapiTestTools(200, createdDataSourceJSON)
+	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
 	defer server.Close()
 
 	ds := &DataSource{
@@ -64,7 +64,7 @@ func TestNewPrometheusDataSource(t *testing.T) {
 
 	created, err := client.NewDataSource(ds)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(created))

--- a/folder_permissions_test.go
+++ b/folder_permissions_test.go
@@ -57,13 +57,13 @@ const (
 )
 
 func TestFolderPermissions(t *testing.T) {
-	server, client := gapiTestTools(200, getFolderPermissionsJSON)
+	server, client := gapiTestTools(t, 200, getFolderPermissionsJSON)
 	defer server.Close()
 
 	fid := "nErXDvCkzz"
 	resp, err := client.FolderPermissions(fid)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -105,7 +105,7 @@ func TestFolderPermissions(t *testing.T) {
 }
 
 func TestUpdateFolderPermissions(t *testing.T) {
-	server, client := gapiTestTools(200, updateFolderPermissionsJSON)
+	server, client := gapiTestTools(t, 200, updateFolderPermissionsJSON)
 	defer server.Close()
 
 	items := &PermissionItems{

--- a/folder_test.go
+++ b/folder_test.go
@@ -85,12 +85,12 @@ const (
 )
 
 func TestFolders(t *testing.T) {
-	server, client := gapiTestTools(200, getFoldersJSON)
+	server, client := gapiTestTools(t, 200, getFoldersJSON)
 	defer server.Close()
 
 	folders, err := client.Folders()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(folders))
@@ -104,13 +104,13 @@ func TestFolders(t *testing.T) {
 }
 
 func TestFolder(t *testing.T) {
-	server, client := gapiTestTools(200, getFolderJSON)
+	server, client := gapiTestTools(t, 200, getFolderJSON)
 	defer server.Close()
 
 	folder := int64(1)
 	resp, err := client.Folder(folder)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -121,12 +121,12 @@ func TestFolder(t *testing.T) {
 }
 
 func TestNewFolder(t *testing.T) {
-	server, client := gapiTestTools(200, createdFolderJSON)
+	server, client := gapiTestTools(t, 200, createdFolderJSON)
 	defer server.Close()
 
 	resp, err := client.NewFolder("test-folder")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -137,21 +137,21 @@ func TestNewFolder(t *testing.T) {
 }
 
 func TestUpdateFolder(t *testing.T) {
-	server, client := gapiTestTools(200, updatedFolderJSON)
+	server, client := gapiTestTools(t, 200, updatedFolderJSON)
 	defer server.Close()
 
 	err := client.UpdateFolder("nErXDvCkzz", "test-folder")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
 func TestDeleteFolder(t *testing.T) {
-	server, client := gapiTestTools(200, deletedFolderJSON)
+	server, client := gapiTestTools(t, 200, deletedFolderJSON)
 	defer server.Close()
 
 	err := client.DeleteFolder("nErXDvCkzz")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }

--- a/mock.go
+++ b/mock.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"testing"
 )
 
 type mockServer struct {
@@ -16,7 +17,9 @@ func (m *mockServer) Close() {
 	m.server.Close()
 }
 
-func gapiTestTools(code int, body string) (*mockServer, *Client) {
+func gapiTestTools(t *testing.T, code int, body string) (*mockServer, *Client) {
+	t.Helper()
+
 	mock := &mockServer{
 		code: code,
 	}
@@ -35,11 +38,9 @@ func gapiTestTools(code int, body string) (*mockServer, *Client) {
 
 	httpClient := &http.Client{Transport: tr}
 
-	url := url.URL{
-		Scheme: "http",
-		Host:   "my-grafana.com",
+	client, err := New("http://my-grafana.com", Config{APIKey: "my-key", Client: httpClient})
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	client := &Client{"my-key", url, httpClient}
 	return mock, client
 }

--- a/org_users_test.go
+++ b/org_users_test.go
@@ -14,13 +14,13 @@ const (
 )
 
 func TestOrgUsers(t *testing.T) {
-	server, client := gapiTestTools(200, getOrgUsersJSON)
+	server, client := gapiTestTools(t, 200, getOrgUsersJSON)
 	defer server.Close()
 
 	org := int64(1)
 	resp, err := client.OrgUsers(org)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -39,31 +39,31 @@ func TestOrgUsers(t *testing.T) {
 }
 
 func TestAddOrgUser(t *testing.T) {
-	server, client := gapiTestTools(200, addOrgUserJSON)
+	server, client := gapiTestTools(t, 200, addOrgUserJSON)
 	defer server.Close()
 
 	orgID, user, role := int64(1), "admin@localhost", "Admin"
 
 	err := client.AddOrgUser(orgID, user, role)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
 func TestUpdateOrgUser(t *testing.T) {
-	server, client := gapiTestTools(200, updateOrgUserJSON)
+	server, client := gapiTestTools(t, 200, updateOrgUserJSON)
 	defer server.Close()
 
 	orgID, userID, role := int64(1), int64(1), "Editor"
 
 	err := client.UpdateOrgUser(orgID, userID, role)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
 func TestRemoveOrgUser(t *testing.T) {
-	server, client := gapiTestTools(200, removeOrgUserJSON)
+	server, client := gapiTestTools(t, 200, removeOrgUserJSON)
 	defer server.Close()
 
 	orgID, userID := int64(1), int64(1)

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -15,12 +15,12 @@ const (
 )
 
 func TestOrgs(t *testing.T) {
-	server, client := gapiTestTools(200, getOrgsJSON)
+	server, client := gapiTestTools(t, 200, getOrgsJSON)
 	defer server.Close()
 
 	orgs, err := client.Orgs()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(orgs))
@@ -34,13 +34,13 @@ func TestOrgs(t *testing.T) {
 }
 
 func TestOrgByName(t *testing.T) {
-	server, client := gapiTestTools(200, getOrgJSON)
+	server, client := gapiTestTools(t, 200, getOrgJSON)
 	defer server.Close()
 
 	org := "Main Org."
 	resp, err := client.OrgByName(org)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -51,13 +51,13 @@ func TestOrgByName(t *testing.T) {
 }
 
 func TestOrg(t *testing.T) {
-	server, client := gapiTestTools(200, getOrgJSON)
+	server, client := gapiTestTools(t, 200, getOrgJSON)
 	defer server.Close()
 
 	org := int64(1)
 	resp, err := client.Org(org)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -68,12 +68,12 @@ func TestOrg(t *testing.T) {
 }
 
 func TestNewOrg(t *testing.T) {
-	server, client := gapiTestTools(200, createdOrgJSON)
+	server, client := gapiTestTools(t, 200, createdOrgJSON)
 	defer server.Close()
 
 	resp, err := client.NewOrg("test-org")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -84,7 +84,7 @@ func TestNewOrg(t *testing.T) {
 }
 
 func TestUpdateOrg(t *testing.T) {
-	server, client := gapiTestTools(200, updatedOrgJSON)
+	server, client := gapiTestTools(t, 200, updatedOrgJSON)
 	defer server.Close()
 
 	err := client.UpdateOrg(int64(1), "test-org")
@@ -94,7 +94,7 @@ func TestUpdateOrg(t *testing.T) {
 }
 
 func TestDeleteOrg(t *testing.T) {
-	server, client := gapiTestTools(200, deletedOrgJSON)
+	server, client := gapiTestTools(t, 200, deletedOrgJSON)
 	defer server.Close()
 
 	err := client.DeleteOrg(int64(1))

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 func TestPlaylistCreateAndUpdate(t *testing.T) {
-	server, client := gapiTestTools(200, createAndUpdatePlaylistResponse)
+	server, client := gapiTestTools(t, 200, createAndUpdatePlaylistResponse)
 	defer server.Close()
 
 	playlist := Playlist{
@@ -74,12 +74,12 @@ func TestPlaylistCreateAndUpdate(t *testing.T) {
 }
 
 func TestGetPlaylist(t *testing.T) {
-	server, client := gapiTestTools(200, getPlaylistResponse)
+	server, client := gapiTestTools(t, 200, getPlaylistResponse)
 	defer server.Close()
 
 	playlist, err := client.Playlist(1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if playlist.ID != 2 {
@@ -92,11 +92,11 @@ func TestGetPlaylist(t *testing.T) {
 }
 
 func TestDeletePlaylist(t *testing.T) {
-	server, client := gapiTestTools(200, "")
+	server, client := gapiTestTools(t, 200, "")
 	defer server.Close()
 
 	err := client.DeletePlaylist(1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }

--- a/teams_test.go
+++ b/teams_test.go
@@ -90,13 +90,13 @@ const (
 )
 
 func TestSearchTeam(t *testing.T) {
-	server, client := gapiTestTools(200, searchTeamJSON)
+	server, client := gapiTestTools(t, 200, searchTeamJSON)
 	defer server.Close()
 
 	query := "myteam"
 	resp, err := client.SearchTeam(query)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -125,13 +125,13 @@ func TestSearchTeam(t *testing.T) {
 }
 
 func TestTeam(t *testing.T) {
-	server, client := gapiTestTools(200, getTeamJSON)
+	server, client := gapiTestTools(t, 200, getTeamJSON)
 	defer server.Close()
 
 	id := int64(1)
 	resp, err := client.Team(id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -153,7 +153,7 @@ func TestTeam(t *testing.T) {
 }
 
 func TestAddTeam(t *testing.T) {
-	server, client := gapiTestTools(200, addTeamsJSON)
+	server, client := gapiTestTools(t, 200, addTeamsJSON)
 	defer server.Close()
 
 	name := "TestTeam"
@@ -169,7 +169,7 @@ func TestAddTeam(t *testing.T) {
 }
 
 func TestUpdateTeam(t *testing.T) {
-	server, client := gapiTestTools(200, updateTeamJSON)
+	server, client := gapiTestTools(t, 200, updateTeamJSON)
 	defer server.Close()
 
 	id := int64(1)
@@ -183,7 +183,7 @@ func TestUpdateTeam(t *testing.T) {
 }
 
 func TestDeleteTeam(t *testing.T) {
-	server, client := gapiTestTools(200, deleteTeamJSON)
+	server, client := gapiTestTools(t, 200, deleteTeamJSON)
 	defer server.Close()
 
 	id := int64(1)
@@ -195,14 +195,14 @@ func TestDeleteTeam(t *testing.T) {
 }
 
 func TestTeamMembers(t *testing.T) {
-	server, client := gapiTestTools(200, getTeamMembersJSON)
+	server, client := gapiTestTools(t, 200, getTeamMembersJSON)
 	defer server.Close()
 
 	id := int64(1)
 
 	resp, err := client.TeamMembers(id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	expects := []*TeamMember{
 		{
@@ -235,7 +235,7 @@ func TestTeamMembers(t *testing.T) {
 }
 
 func TestAddTeamMember(t *testing.T) {
-	server, client := gapiTestTools(200, addTeamMemberJSON)
+	server, client := gapiTestTools(t, 200, addTeamMemberJSON)
 	defer server.Close()
 
 	id := int64(1)
@@ -247,7 +247,7 @@ func TestAddTeamMember(t *testing.T) {
 }
 
 func TestRemoveMemberFromTeam(t *testing.T) {
-	server, client := gapiTestTools(200, removeMemberFromTeamJSON)
+	server, client := gapiTestTools(t, 200, removeMemberFromTeamJSON)
 	defer server.Close()
 
 	id := int64(1)
@@ -259,14 +259,14 @@ func TestRemoveMemberFromTeam(t *testing.T) {
 }
 
 func TestTeamPreferences(t *testing.T) {
-	server, client := gapiTestTools(200, getTeamPreferencesJSON)
+	server, client := gapiTestTools(t, 200, getTeamPreferencesJSON)
 	defer server.Close()
 
 	id := int64(1)
 
 	resp, err := client.TeamPreferences(id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	expect := &Preferences{
 		Theme:           "",
@@ -282,7 +282,7 @@ func TestTeamPreferences(t *testing.T) {
 }
 
 func TestUpdateTeamPreferences(t *testing.T) {
-	server, client := gapiTestTools(200, updateTeamPreferencesJSON)
+	server, client := gapiTestTools(t, 200, updateTeamPreferencesJSON)
 	defer server.Close()
 
 	id := int64(1)

--- a/user_test.go
+++ b/user_test.go
@@ -14,12 +14,12 @@ const (
 )
 
 func TestUsers(t *testing.T) {
-	server, client := gapiTestTools(200, getUsersJSON)
+	server, client := gapiTestTools(t, 200, getUsersJSON)
 	defer server.Close()
 
 	resp, err := client.Users()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
@@ -38,12 +38,12 @@ func TestUsers(t *testing.T) {
 }
 
 func TestUser(t *testing.T) {
-	server, client := gapiTestTools(200, getUserJSON)
+	server, client := gapiTestTools(t, 200, getUserJSON)
 	defer server.Close()
 
 	user, err := client.User(1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(user))
@@ -56,12 +56,12 @@ func TestUser(t *testing.T) {
 }
 
 func TestUserByEmail(t *testing.T) {
-	server, client := gapiTestTools(200, getUserByEmailJSON)
+	server, client := gapiTestTools(t, 200, getUserByEmailJSON)
 	defer server.Close()
 
 	user, err := client.UserByEmail("admin@localhost")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(user))
@@ -74,12 +74,12 @@ func TestUserByEmail(t *testing.T) {
 }
 
 func TestUserUpdate(t *testing.T) {
-	server, client := gapiTestTools(200, getUserUpdateJSON)
+	server, client := gapiTestTools(t, 200, getUserUpdateJSON)
 	defer server.Close()
 
 	user, err := client.User(4)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	user.IsAdmin = true
 	err = client.UserUpdate(user)


### PR DESCRIPTION
Re-design client.New so it takes a configuration object. Makes configuration a lot more sensible, and extensible (I took inspiration from the AWS [Go SDK](https://docs.aws.amazon.com/sdk-for-go/api/aws/client/#New)).

This re-design is motivated by PR #9, which proposes to add an org ID parameter. From how I understand @marefr however, passing an org ID only makes sense when using basic auth, so a better design is to introduce a configuration object that lets you configure either an API key or basic auth, plus an optional org ID (which is only valid together with basic auth). With the config parameter, we are also free to add more configuration parameters (in addition to org ID) in the future.

**NB:**
This PR also makes `client.Client.Client` private, so you can't call HTTP client methods on it. I figure it's more sensible/maintainable to not expose those methods directly. Does that break anything for users of the lib?

If anyone actually uses HTTP client methods on `Client`, we should probably provide them with more high-level methods.