### PR TITLE
Add Deprecation Notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# grafana-api-golang-client
+# DEPRECATED
+
+:warning: :warning: :warning:
+
+**This repository is no longer being maintained.**
+
+We're in the process of creating our next generation API clients.
+
+In the interim, further changes to this repository should only be to support
+[grafana/terraform-provider-grafana](https://github.com/grafana/terraform-provider-grafana).
+
+---
 
 Grafana HTTP API Client for Go
 


### PR DESCRIPTION
We'd like to deprecate this repository so we can focus on the creation of our next generation API clients.

The message is intended to make it clear to folks that stumble upon this repository that we do not intend to keep it up to date. And to discourage the use of this client as a dependency for other projects.

I've mentioned [grafana/terraform-provider-grafana](https://github.com/grafana/terraform-provider-grafana) since this is the only project of significance we're aware of that uses this client. We will continue to support the Terraform provider with this client until we have a better alternative.