### PR TITLE
Add support for providing additional HTTP headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,6 +29,8 @@ type Config struct {
 	APIKey string
 	// BasicAuth is optional basic auth credentials.
 	BasicAuth *url.Userinfo
+	// HTTPHeaders are optional HTTP headers.
+	HTTPHeaders map[string]string
 	// Client provides an optional HTTP client, otherwise a default will be used.
 	Client *http.Client
 	// OrgID provides an optional organization ID, ignored when using APIKey, BasicAuth defaults to last used org
@@ -108,6 +110,11 @@ func (c *Client) newRequest(method, requestPath string, query url.Values, body i
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.config.APIKey))
 	} else if c.config.OrgID != 0 {
 		req.Header.Add("X-Grafana-Org-Id", strconv.FormatInt(c.config.OrgID, 10))
+	}
+	if c.config.HTTPHeaders != nil {
+		for k, v := range c.config.HTTPHeaders {
+			req.Header.Add(k, v)
+		}
 	}
 
 	if os.Getenv("GF_LOG") != "" {

--- a/client_test.go
+++ b/client_test.go
@@ -53,6 +53,23 @@ func TestNew_orgID(t *testing.T) {
 	}
 }
 
+func TestNew_HTTPHeaders(t *testing.T) {
+	const key = "foo"
+	headers := map[string]string{key: "bar"}
+	c, err := New("http://my-grafana.com", Config{HTTPHeaders: headers})
+	if err != nil {
+		t.Fatalf("expected error to be nil; got: %s", err.Error())
+	}
+
+	value, ok := c.config.HTTPHeaders[key]
+	if !ok {
+		t.Errorf("expected error: %v; got: %v", headers, c.config.HTTPHeaders)
+	}
+	if value != headers[key] {
+		t.Errorf("expected error: %s; got: %s", headers[key], value)
+	}
+}
+
 func TestNew_invalidURL(t *testing.T) {
 	_, err := New("://my-grafana.com", Config{APIKey: "123"})
 


### PR DESCRIPTION
Sometimes the Grafana server is behind a proxy or application firewall and it is necessary to provide additional HTTP headers to establish a connection, such as authentication tokens or cookies. In general sense these are represented as key-value pairs of strings.

This PR is based on https://github.com/nytm/go-grafana-api/pull/63.