### PR TITLE
Fix json_data field types for opentsdb datasource

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -58,8 +58,8 @@ type JSONData struct {
 	CustomMetricsNamespaces string `json:"customMetricsNamespaces,omitempty"`
 
 	// Used by OpenTSDB
-	TsdbVersion    string `json:"tsdbVersion,omitempty"`
-	TsdbResolution string `json:"tsdbResolution,omitempty"`
+	TsdbVersion    int64 `json:"tsdbVersion,omitempty"`
+	TsdbResolution int64 `json:"tsdbResolution,omitempty"`
 
 	// Used by MSSQL
 	Encrypt string `json:"encrypt,omitempty"`

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -73,3 +73,31 @@ func TestNewPrometheusDataSource(t *testing.T) {
 		t.Error("datasource creation response should return the created datasource ID")
 	}
 }
+
+func TestNewOpenTSDBDataSource(t *testing.T) {
+	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
+	defer server.Close()
+
+	ds := &DataSource{
+		Name:      "foo_opentsdb",
+		Type:      "opentsdb",
+		URL:       "http://some-url.com",
+		Access:    "access",
+		IsDefault: true,
+		JSONData: JSONData{
+			TsdbResolution: 1,
+			TsdbVersion:    3,
+		},
+	}
+
+	created, err := client.NewDataSource(ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(pretty.PrettyFormat(created))
+
+	if created != 1 {
+		t.Error("datasource creation response should return the created datasource ID")
+	}
+}


### PR DESCRIPTION
`tsdb_resolution` and `tsdb_version` were declared as strings though
those fields are integers.

See https://github.com/grafana/terraform-provider-grafana/issues/140