### PR TITLE
Add support for dashboard permissions

### DIFF
--- a/dashboard_permissions.go
+++ b/dashboard_permissions.go
@@ -1,0 +1,47 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// DashboardPermission has information such as a dashboard, user, team, role and permission.
+type DashboardPermission struct {
+	DashboardID  int64  `json:"dashboardId"`
+	DashboardUID string `json:"uid"`
+	UserID       int64  `json:"userId"`
+	TeamID       int64  `json:"teamId"`
+	Role         string `json:"role"`
+	IsFolder     bool   `json:"isFolder"`
+	Inherited    bool   `json:"inherited"`
+
+	// Permission levels are
+	// 1 = View
+	// 2 = Edit
+	// 4 = Admin
+	Permission     int64  `json:"permission"`
+	PermissionName string `json:"permissionName"`
+}
+
+// DashboardPermissions fetches and returns the permissions for the dashboard whose ID it's passed.
+func (c *Client) DashboardPermissions(id int64) ([]*DashboardPermission, error) {
+	permissions := make([]*DashboardPermission, 0)
+	err := c.request("GET", fmt.Sprintf("/api/dashboards/id/%d/permissions", id), nil, nil, &permissions)
+	if err != nil {
+		return permissions, err
+	}
+
+	return permissions, nil
+}
+
+// UpdateDashboardPermissions remove existing permissions if items are not included in the request.
+func (c *Client) UpdateDashboardPermissions(id int64, items *PermissionItems) error {
+	path := fmt.Sprintf("/api/dashboards/id/%d/permissions", id)
+	data, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+
+	return c.request("POST", path, nil, bytes.NewBuffer(data), nil)
+}

--- a/dashboard_permissions_test.go
+++ b/dashboard_permissions_test.go
@@ -7,11 +7,10 @@ import (
 )
 
 const (
-	getFolderPermissionsJSON = `
+	getDashboardPermissionsJSON = `
 [
   {
-    "id": 1,
-    "folderId": -1,
+    "dashboardId": 1,
     "created": "2017-06-20T02:00:00+02:00",
     "updated": "2017-06-20T02:00:00+02:00",
     "userId": 0,
@@ -26,11 +25,11 @@ const (
     "title": "",
     "slug": "",
     "isFolder": false,
-    "url": ""
+    "url": "",
+    "inherited": false
   },
   {
-    "id": 2,
-    "dashboardId": -1,
+    "dashboardId": 2,
     "created": "2017-06-20T02:00:00+02:00",
     "updated": "2017-06-20T02:00:00+02:00",
     "userId": 0,
@@ -41,71 +40,77 @@ const (
     "role": "Editor",
     "permission": 2,
     "permissionName": "Edit",
-    "uid": "",
+    "uid": "nErXDvCkzz",
     "title": "",
     "slug": "",
     "isFolder": false,
-    "url": ""
+    "url": "",
+    "inherited": true
   }
 ]
 `
-	updateFolderPermissionsJSON = `
+	updateDashboardPermissionsJSON = `
 {
-	"message": "Folder permissions updated"
+	"message": "Dashboard permissions updated"
 }
 `
 )
 
-func TestFolderPermissions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getFolderPermissionsJSON)
+func TestDashboardPermissions(t *testing.T) {
+	server, client := gapiTestTools(t, 200, getDashboardPermissionsJSON)
 	defer server.Close()
 
-	fid := "nErXDvCkzz"
-	resp, err := client.FolderPermissions(fid)
+	resp, err := client.DashboardPermissions(1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	expects := []*FolderPermission{
+	expects := []*DashboardPermission{
 		{
-			ID:             1,
-			FolderUID:      "nErXDvCkzz",
+			DashboardID:    1,
+			DashboardUID:   "nErXDvCkzz",
+			Role:           "Viewer",
 			UserID:         0,
 			TeamID:         0,
-			Role:           "Viewer",
 			IsFolder:       false,
+			Inherited:      false,
 			Permission:     1,
 			PermissionName: "View",
-			FolderID:       -1,
-			DashboardID:    0,
 		},
 		{
-			ID:             2,
-			FolderUID:      "",
+			DashboardID:    2,
+			DashboardUID:   "nErXDvCkzz",
+			Role:           "Editor",
 			UserID:         0,
 			TeamID:         0,
-			Role:           "Editor",
 			IsFolder:       false,
+			Inherited:      true,
 			Permission:     2,
 			PermissionName: "Edit",
-			FolderID:       0,
-			DashboardID:    -1,
 		},
 	}
 
 	for i, expect := range expects {
 		t.Run("check data", func(t *testing.T) {
-			if resp[i].ID != expect.ID || resp[i].Role != expect.Role {
-				t.Error("Not correctly parsing returned folder permission")
+			if resp[i].DashboardID != expect.DashboardID ||
+				resp[i].DashboardUID != expect.DashboardUID ||
+				resp[i].Role != expect.Role ||
+				resp[i].UserID != expect.UserID ||
+				resp[i].TeamID != expect.TeamID ||
+				resp[i].IsFolder != expect.IsFolder ||
+				resp[i].Inherited != expect.Inherited ||
+				resp[i].Permission != expect.Permission ||
+				resp[i].PermissionName != expect.PermissionName {
+				t.Error("Not correctly parsing returned dashboard permission")
 			}
 		})
 	}
 }
 
-func TestUpdateFolderPermissions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateFolderPermissionsJSON)
+func TestUpdateDashboardPermissions(t *testing.T) {
+	server, client := gapiTestTools(t, 200, updateDashboardPermissionsJSON)
 	defer server.Close()
 
 	items := &PermissionItems{
@@ -128,7 +133,7 @@ func TestUpdateFolderPermissions(t *testing.T) {
 			},
 		},
 	}
-	err := client.UpdateFolderPermissions("nErXDvCkzz", items)
+	err := client.UpdateDashboardPermissions(1, items)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Adds functions for dashboard permissions.

Required for terraform-provider-grafana. See https://github.com/grafana/terraform-provider-grafana/issues/51#issuecomment-535144053