### PR TITLE
updated with secureSettings and secureFields for tf provider support

### DIFF
--- a/alertnotification.go
+++ b/alertnotification.go
@@ -17,6 +17,8 @@ type AlertNotification struct {
 	SendReminder          bool        `json:"sendReminder"`
 	Frequency             string      `json:"frequency"`
 	Settings              interface{} `json:"settings"`
+	SecureFields          interface{} `json:"secureFields,omitempty"`
+	SecureSettings        interface{} `json:"secureSettings,omitempty"`
 }
 
 // AlertNotifications fetches and returns Grafana alert notifications.


### PR DESCRIPTION
Add support for secure_settings in alertchanel resource implementation

Secure Settings:
https://grafana.com/docs/grafana/latest/administration/provisioning/#supported-settings 

https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/alert_notification#example-usage

```
settings = {​​​​​​​
  uploadImage = "false"
  apiUrl = "https://api.opsgenie.com/v2/alerts"
}​​​​​​​
secure_settings = {​​​​​​​
  apiKey = each.value
}​​​​​​​
```

Avoid having apiKeys and passwords exposed via UI if using tf provider to configure grafana alertnotifications
