### PR TITLE
added the profile field in JSONData for Cloudwatch datasources

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -56,6 +56,7 @@ type JSONData struct {
 	AssumeRoleArn           string `json:"assumeRoleArn,omitempty"`
 	DefaultRegion           string `json:"defaultRegion,omitempty"`
 	CustomMetricsNamespaces string `json:"customMetricsNamespaces,omitempty"`
+	Profile                 string `json:"profile,omitempty"`
 
 	// Used by OpenTSDB
 	TsdbVersion    string `json:"tsdbVersion,omitempty"`


### PR DESCRIPTION
In the latest version of Grafana, [AWS CloudWatch datasources](https://grafana.com/docs/grafana/latest/datasources/cloudwatch/) can be defined with "_Authentication Provider = Credentials file_" which stores the access and secret keys while it is possible to provide "Credentials profile name" to specify the name of the profile to use in _~/.aws/credentials_ file.

This pull-request adds support to set the "profile name" while creating CloudWatch datasources and helps fix required for [Issue-154](https://github.com/grafana/terraform-provider-grafana/issues/154) of [grafana/terraform-provider-grafana](https://github.com/grafana/terraform-provider-grafana).