### PR TITLE
correct elasticsearch Interval field

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -47,7 +47,7 @@ type JSONData struct {
 	// Used by Elasticsearch
 	EsVersion       int64  `json:"esVersion,omitempty"`
 	TimeField       string `json:"timeField,omitempty"`
-	Interval        string `json:"inteval,omitempty"`
+	Interval        string `json:"interval,omitempty"`
 	LogMessageField string `json:"logMessageField,omitempty"`
 	LogLevelField   string `json:"logLevelField,omitempty"`
 


### PR DESCRIPTION
Currently Elasticsearch Datasources are broken as the interveral JSON is passed to Grafana as inteval which means it doesnt get processed

```
resource "grafana_data_source" "elasticsearch" {
  type          = "elasticsearch"
  name          = "elasticsearch_tf"
  url           = "https://SNIP.es.amazonaws.com"
  database_name = "[something-]YYYY.MM.DD"
  json_data {
    interval          = "Yearly"
    time_field        = "@timestamp"
    es_version        = "70"
    time_interval     = "60s"
    log_message_field = "message"
  }
}
```
Turns out as this, with **inteval**
```
{
    "id": 2,
    "uid": "L4Zk2FEMk",
    "orgId": 3,
    "name": "elasticsearch_tf",
    "type": "elasticsearch",
    "typeLogoUrl": "public/app/plugins/datasource/elasticsearch/img/elasticsearch.svg",
    "access": "proxy",
    "url": "https://SNIP.es.amazonaws.com",
    "password": "",
    "user": "",
    "database": "[something-]YYYY.MM.DD",
    "basicAuth": false,
    "isDefault": false,
    "jsonData": {
      "esVersion": 70,
      "inteval": "Yearly",
      "logMessageField": "message",
      "timeField": "@timestamp",
      "timeInterval": "60s"
    },
    "readOnly": false
  },
  ```

Issue referenced in https://github.com/grafana/terraform-provider-grafana/issues/135