### PR TITLE
Add MaxConcurrentShardRequests in json_data

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -45,11 +45,12 @@ type JSONData struct {
 	TimeInterval string `json:"timeInterval,omitempty"`
 
 	// Used by Elasticsearch
-	EsVersion       int64  `json:"esVersion,omitempty"`
-	TimeField       string `json:"timeField,omitempty"`
-	Interval        string `json:"inteval,omitempty"`
-	LogMessageField string `json:"logMessageField,omitempty"`
-	LogLevelField   string `json:"logLevelField,omitempty"`
+	EsVersion                  int64  `json:"esVersion,omitempty"`
+	TimeField                  string `json:"timeField,omitempty"`
+	Interval                   string `json:"inteval,omitempty"`
+	LogMessageField            string `json:"logMessageField,omitempty"`
+	LogLevelField              string `json:"logLevelField,omitempty"`
+	MaxConcurrentShardRequests int64  `json:"maxConcurrentShardRequests,omitempty"`
 
 	// Used by Cloudwatch
 	AuthType                string `json:"authType,omitempty"`

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -73,3 +73,34 @@ func TestNewPrometheusDataSource(t *testing.T) {
 		t.Error("datasource creation response should return the created datasource ID")
 	}
 }
+
+func TestNewElasticsearchDataSource(t *testing.T) {
+	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
+	defer server.Close()
+
+	ds := &DataSource{
+		Name:      "foo_elasticsearch",
+		Type:      "elasticsearch",
+		URL:       "http://some-url.com",
+		IsDefault: true,
+		JSONData: JSONData{
+			EsVersion:                  70,
+			TimeField:                  "time",
+			Interval:                   "1m",
+			LogMessageField:            "message",
+			LogLevelField:              "field",
+			MaxConcurrentShardRequests: 8,
+		},
+	}
+
+	created, err := client.NewDataSource(ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(pretty.PrettyFormat(created))
+
+	if created != 1 {
+		t.Error("datasource creation response should return the created datasource ID")
+	}
+}


### PR DESCRIPTION
Add `MaxConcurrentShardRequests` field in `json_data` for **Elasticsearch datasource**.

**Terraform-provider-grafana:** https://github.com/grafana/terraform-provider-grafana/issues/195