### PR TITLE
Add AWS SigV4 auth support

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -85,6 +85,14 @@ type JSONData struct {
 	ClientEmail        string `json:"clientEmail,omitempty"`
 	DefaultProject     string `json:"defaultProject,omitempty"`
 	TokenURI           string `json:"tokenUri,omitempty"`
+
+	// Used by Prometheus and Elasticsearch
+	SigV4AssumeRoleArn string `json:"sigV4AssumeRoleArn,omitempty"`
+	SigV4Auth          bool   `json:"sigV4Auth,omitempty"`
+	SigV4AuthType      string `json:"sigV4AuthType,omitempty"`
+	SigV4ExternalID    string `json:"sigV4ExternalID,omitempty"`
+	SigV4Profile       string `json:"sigV4Profile,omitempty"`
+	SigV4Region        string `json:"sigV4Region,omitempty"`
 }
 
 // SecureJSONData is a representation of the datasource `secureJsonData` property
@@ -102,6 +110,10 @@ type SecureJSONData struct {
 
 	// Used by Stackdriver
 	PrivateKey string `json:"privateKey,omitempty"`
+
+	// Used by Prometheus and Elasticsearch
+	SigV4AccessKey string `json:"sigV4AccessKey,omitempty"`
+	SigV4SecretKey string `json:"sigV4SecretKey,omitempty"`
 }
 
 // NewDataSource creates a new Grafana data source.

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -74,6 +74,40 @@ func TestNewPrometheusDataSource(t *testing.T) {
 	}
 }
 
+func TestNewPrometheusSigV4DataSource(t *testing.T) {
+	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
+	defer server.Close()
+
+	ds := &DataSource{
+		Name:      "sigv4_prometheus",
+		Type:      "prometheus",
+		URL:       "http://some-url.com",
+		Access:    "access",
+		IsDefault: true,
+		JSONData: JSONData{
+			HTTPMethod:    "POST",
+			SigV4Auth:     true,
+			SigV4AuthType: "keys",
+			SigV4Region:   "us-east-1",
+		},
+		SecureJSONData: SecureJSONData{
+			SigV4AccessKey: "123",
+			SigV4SecretKey: "456",
+		},
+	}
+
+	created, err := client.NewDataSource(ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(pretty.PrettyFormat(created))
+
+	if created != 1 {
+		t.Error("datasource creation response should return the created datasource ID")
+	}
+}
+
 func TestNewElasticsearchDataSource(t *testing.T) {
 	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
 	defer server.Close()


### PR DESCRIPTION
I would like to add AWS SigV4 auth support to the [terraform-provider-grafana](https://github.com/grafana/terraform-provider-grafana).
See https://github.com/grafana/terraform-provider-grafana/issues/193