### PR TITLE
Datasource - ElasticSearch. Fixed + added fields

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -45,12 +45,12 @@ type JSONData struct {
 	TimeInterval string `json:"timeInterval,omitempty"`
 
 	// Used by Elasticsearch
-	EsVersion                    int64  `json:"esVersion,omitempty"`
-	TimeField                    string `json:"timeField,omitempty"`
-	Interval                     string `json:"interval,omitempty"`
-	LogMessageField              string `json:"logMessageField,omitempty"`
-	LogLevelField                string `json:"logLevelField,omitempty"`
-	MaxConcurrentShardRequests   int64  `json:"maxConcurrentShardRequests,omitempty"`
+	EsVersion                  int64  `json:"esVersion,omitempty"`
+	TimeField                  string `json:"timeField,omitempty"`
+	Interval                   string `json:"interval,omitempty"`
+	LogMessageField            string `json:"logMessageField,omitempty"`
+	LogLevelField              string `json:"logLevelField,omitempty"`
+	MaxConcurrentShardRequests int64  `json:"maxConcurrentShardRequests,omitempty"`
 
 	// Used by Cloudwatch
 	AuthType                string `json:"authType,omitempty"`

--- a/datasource.go
+++ b/datasource.go
@@ -45,11 +45,12 @@ type JSONData struct {
 	TimeInterval string `json:"timeInterval,omitempty"`
 
 	// Used by Elasticsearch
-	EsVersion       int64  `json:"esVersion,omitempty"`
-	TimeField       string `json:"timeField,omitempty"`
-	Interval        string `json:"inteval,omitempty"`
-	LogMessageField string `json:"logMessageField,omitempty"`
-	LogLevelField   string `json:"logLevelField,omitempty"`
+	EsVersion                    int64  `json:"esVersion,omitempty"`
+	TimeField                    string `json:"timeField,omitempty"`
+	Interval                     string `json:"interval,omitempty"`
+	LogMessageField              string `json:"logMessageField,omitempty"`
+	LogLevelField                string `json:"logLevelField,omitempty"`
+	MaxConcurrentShardRequests   int64  `json:"maxConcurrentShardRequests,omitempty"`
 
 	// Used by Cloudwatch
 	AuthType                string `json:"authType,omitempty"`


### PR DESCRIPTION
The grafana api takes a field "interval" but this currently has a typo "inteval" which is preventing it being read.
Additionally, I've added a maxConcurrentShardRequests field which can already be configured in the grafana api (for ES > 5.6+) but was missing from the datasource.