### PR TITLE
FolderDashboardSearch

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/url"
 )
 
 // DashboardMeta represents Grafana dashboard meta.
@@ -21,23 +20,6 @@ type DashboardSaveResponse struct {
 	UID     string `json:"uid"`
 	Status  string `json:"status"`
 	Version int64  `json:"version"`
-}
-
-// DashboardSearchResponse represents the Grafana API dashboard search response.
-type DashboardSearchResponse struct {
-	ID          uint     `json:"id"`
-	UID         string   `json:"uid"`
-	Title       string   `json:"title"`
-	URI         string   `json:"uri"`
-	URL         string   `json:"url"`
-	Slug        string   `json:"slug"`
-	Type        string   `json:"type"`
-	Tags        []string `json:"tags"`
-	IsStarred   bool     `json:"isStarred"`
-	FolderID    uint     `json:"folderId"`
-	FolderUID   string   `json:"folderUid"`
-	FolderTitle string   `json:"folderTitle"`
-	FolderURL   string   `json:"folderUrl"`
 }
 
 // Dashboard represents a Grafana dashboard.
@@ -85,19 +67,12 @@ func (c *Client) NewDashboard(dashboard Dashboard) (*DashboardSaveResponse, erro
 	return result, err
 }
 
-// Dashboards fetches and returns Grafana dashboards.
-func (c *Client) Dashboards() ([]DashboardSearchResponse, error) {
-	dashboards := make([]DashboardSearchResponse, 0)
-	query := url.Values{}
-	// search only dashboards
-	query.Add("type", "dash-db")
-
-	err := c.request("GET", "/api/search", query, nil, &dashboards)
-	if err != nil {
-		return nil, err
+// Dashboards fetches and returns all dashboards.
+func (c *Client) Dashboards() ([]FolderDashboardSearchResponse, error) {
+	params := map[string]string{
+		"type": "dash-db",
 	}
-
-	return dashboards, err
+	return c.FolderDashboardSearch(params)
 }
 
 // Dashboard will be removed.

--- a/folder_dashboard_search.go
+++ b/folder_dashboard_search.go
@@ -1,0 +1,36 @@
+package gapi
+
+import (
+	"net/url"
+)
+
+// FolderDashboardSearchResponse represents the Grafana API dashboard search response.
+type FolderDashboardSearchResponse struct {
+	ID          uint     `json:"id"`
+	UID         string   `json:"uid"`
+	Title       string   `json:"title"`
+	URI         string   `json:"uri"`
+	URL         string   `json:"url"`
+	Slug        string   `json:"slug"`
+	Type        string   `json:"type"`
+	Tags        []string `json:"tags"`
+	IsStarred   bool     `json:"isStarred"`
+	FolderID    uint     `json:"folderId"`
+	FolderUID   string   `json:"folderUid"`
+	FolderTitle string   `json:"folderTitle"`
+	FolderURL   string   `json:"folderUrl"`
+}
+
+// FolderDashboardSearch uses the folder and dashboard search endpoint to find
+// dashboards based on the params passed in.
+func (c *Client) FolderDashboardSearch(params map[string]string) (resp []FolderDashboardSearchResponse, err error) {
+	query := url.Values{}
+	for p, v := range params {
+		query.Add(p, v)
+	}
+	err = c.request("GET", "/api/search", query, nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}

--- a/folder_dashboard_search.go
+++ b/folder_dashboard_search.go
@@ -29,8 +29,5 @@ func (c *Client) FolderDashboardSearch(params map[string]string) (resp []FolderD
 		query.Add(p, v)
 	}
 	err = c.request("GET", "/api/search", query, nil, &resp)
-	if err != nil {
-		return nil, err
-	}
 	return
 }

--- a/folder_dashboard_search_test.go
+++ b/folder_dashboard_search_test.go
@@ -1,0 +1,62 @@
+package gapi
+
+import (
+	"testing"
+)
+
+const (
+
+	// This response is copied from the examples in the API docs:
+	// https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/
+	getFolderDashboardSearchResponse = `[
+		{
+			"id": 163,
+			"uid": "000000163",
+			"title": "Folder",
+			"url": "/dashboards/f/000000163/folder",
+			"type": "dash-folder",
+			"tags": [],
+			"isStarred": false,
+			"uri":"db/folder"
+		},
+		{
+			"id":1,
+			"uid": "cIBgcSjkk",
+			"title":"Production Overview",
+			"url": "/d/cIBgcSjkk/production-overview",
+			"type":"dash-db",
+			"tags":["prod"],
+			"isStarred":true,
+			"uri":"db/production-overview"
+		},
+		{
+			"id":1,
+			"uid": "cIBgcSjkk",
+			"title":"Production Overview",
+			"url": "/d/cIBgcSjkk/production-overview",
+			"type":"dash-db",
+			"tags":["prod"],
+			"isStarred":true,
+			"folderId": 2,
+			"folderUid": "000000163",
+			"folderTitle": "Folder",
+			"folderUrl": "/dashboards/f/000000163/folder",
+			"uri":"db/production-overview"
+		}
+	]`
+)
+
+func TestFolderDashboardSearch(t *testing.T) {
+	server, client := gapiTestTools(t, 200, getFolderDashboardSearchResponse)
+	defer server.Close()
+	resp, err := client.FolderDashboardSearch(map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp) != 3 {
+		t.Errorf("Expected 3 objects in response, got %d", len(resp))
+	}
+	if resp[0].ID != 163 || resp[0].Title != "Folder" {
+		t.Error("Not correctly parsing response.")
+	}
+}


### PR DESCRIPTION
Implements [Folder/Dashboard Search API](https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/). This is necessary for implementing a StateUpgrader for migrating the Terraform provider dashboard resource from slug to UID https://github.com/grafana/terraform-provider-grafana/pull/217#discussion_r653812645.