### PR TITLE
OrgUsersCurrent: GET /api/org/users

### DIFF
--- a/org_users.go
+++ b/org_users.go
@@ -15,6 +15,17 @@ type OrgUser struct {
 	Role   string `json:"role"`
 }
 
+// OrgUsersCurrent returns all org users within the current organization.
+// This endpoint is accessible to users with org admin role.
+func (c *Client) OrgUsersCurrent() ([]OrgUser, error) {
+	users := make([]OrgUser, 0)
+	err := c.request("GET", "/api/org/users", nil, nil, &users)
+	if err != nil {
+		return nil, err
+	}
+	return users, err
+}
+
 // OrgUsers fetches and returns the users for the org whose ID it's passed.
 func (c *Client) OrgUsers(orgID int64) ([]OrgUser, error) {
 	users := make([]OrgUser, 0)

--- a/org_users_test.go
+++ b/org_users_test.go
@@ -13,6 +13,28 @@ const (
 	removeOrgUserJSON = `{"message":"User removed from organization"}`
 )
 
+func TestOrgUsersCurrent(t *testing.T) {
+	server, client := gapiTestTools(t, 200, getOrgUsersJSON)
+	defer server.Close()
+
+	resp, err := client.OrgUsersCurrent()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	user := OrgUser{
+		OrgID:  1,
+		UserID: 1,
+		Email:  "admin@localhost",
+		Login:  "admin",
+		Role:   "Admin",
+	}
+
+	if resp[0] != user {
+		t.Error("Not correctly parsing returned organization users.")
+	}
+}
+
 func TestOrgUsers(t *testing.T) {
 	server, client := gapiTestTools(t, 200, getOrgUsersJSON)
 	defer server.Close()


### PR DESCRIPTION
Returns all org users within the current organization. Accessible to
users with org admin role.

https://grafana.com/docs/grafana/latest/http_api/org/#get-all-users-within-the-current-organization

This is not an admin org endpoint so basic auth is not required.