### PR TITLE
Update EsVersion type to string from int for datasource client

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -45,7 +45,8 @@ type JSONData struct {
 	TimeInterval string `json:"timeInterval,omitempty"`
 
 	// Used by Elasticsearch
-	EsVersion                  int64  `json:"esVersion,omitempty"`
+	// From Grafana 8.x esVersion is the semantic version of Elasticsearch.
+	EsVersion                  string `json:"esVersion,omitempty"`
 	TimeField                  string `json:"timeField,omitempty"`
 	Interval                   string `json:"interval,omitempty"`
 	LogMessageField            string `json:"logMessageField,omitempty"`

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -118,7 +118,7 @@ func TestNewElasticsearchDataSource(t *testing.T) {
 		URL:       "http://some-url.com",
 		IsDefault: true,
 		JSONData: JSONData{
-			EsVersion:                  70,
+			EsVersion:                  "7.0.0",
 			TimeField:                  "time",
 			Interval:                   "1m",
 			LogMessageField:            "message",


### PR DESCRIPTION
EsVersion used to be an integer prior to Grafana 8.x. This is considered legacy now and full semantic version as a string is used instead.