### PR TITLE
correct `GET /api/annotations` path

### DIFF
--- a/annotation.go
+++ b/annotation.go
@@ -38,7 +38,7 @@ type GraphiteAnnotation struct {
 // Annotations fetches the annotations queried with the params it's passed
 func (c *Client) Annotations(params url.Values) ([]Annotation, error) {
 	result := []Annotation{}
-	err := c.request("GET", "/api/annotation", params, nil, &result)
+	err := c.request("GET", "/api/annotations", params, nil, &result)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This corrects the [GET /api/annotations](https://grafana.com/docs/grafana/latest/http_api/annotations/) URL path.

The correct path is `/api/annotations` and not `/api/annotation`.

For further context, see:
https://github.com/grafana/terraform-provider-grafana/issues/11#issuecomment-797424562

Thanks!