### PR TITLE
Remove deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grafana HTTP API Client for Go
 
-This library provides a low-level client to access Grafaba [HTTP API](https://grafana.com/docs/grafana/latest/http_api/).
+This library provides a low-level client to access Grafana [HTTP API](https://grafana.com/docs/grafana/latest/http_api/).
 
 :warning: This repository is still active but not under heavy development.
 Contributions to this library offering support for the [Terraform provider for Grafana](https://github.com/grafana/terraform-provider-grafana) will be prioritized over generic ones.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,9 @@
-# DEPRECATED
+# Grafana HTTP API Client for Go
 
-:warning: :warning: :warning:
+This library provides a low-level client to access Grafaba [HTTP API](https://grafana.com/docs/grafana/latest/http_api/).
 
-**This repository is no longer being maintained.**
-
-We're in the process of creating our next generation API clients.
-
-In the interim, further changes to this repository should only be to support
-[grafana/terraform-provider-grafana](https://github.com/grafana/terraform-provider-grafana).
-
----
-
-Grafana HTTP API Client for Go
+:warning: This repository is still active but not under heavy development.
+Contributions to this library offering support for the [Terraform provider for Grafana](https://github.com/grafana/terraform-provider-grafana) will be prioritized over generic ones.
 
 ## Tests
 


### PR DESCRIPTION
After talking with @trotttrotttrott we came to the conclusion that the next generation API client won't be available any time soon, and we continue to accept contributions to it from time to time.

Note that removing the deprecation warning doesn't mean we have a roadmap for upgrades, this just removes the deprecation notice that might scare the community from sending contributions.