### PR TITLE
Add uid to datasource - Grafana Provider for terraform Prerequisite

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -9,6 +9,7 @@ import (
 // DataSource represents a Grafana data source.
 type DataSource struct {
 	ID     int64  `json:"id,omitempty"`
+	UID    string `json:"uid"`
 	Name   string `json:"name"`
 	Type   string `json:"type"`
 	URL    string `json:"url"`

--- a/datasource.go
+++ b/datasource.go
@@ -9,7 +9,7 @@ import (
 // DataSource represents a Grafana data source.
 type DataSource struct {
 	ID     int64  `json:"id,omitempty"`
-	UID    string `json:"uid"`
+	UID    string `json:"uid,omitempty"`
 	Name   string `json:"name"`
 	Type   string `json:"type"`
 	URL    string `json:"url"`

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	createdDataSourceJSON = `{"id":1,"message":"Datasource added", "name": "test_datasource"}`
+	createdDataSourceJSON = `{"id":1,"uid":"myuid0001","message":"Datasource added", "name": "test_datasource"}`
 )
 
 func TestNewDataSource(t *testing.T) {


### PR DESCRIPTION
Due to changes in Grafana 8, provisioning dashboards using terraform is currently not working as `uid` isn't available as an attribute for the `grafana_data_source` resource.

This PR adds uid, a follow-up PR will be opened against [the Grafana provider](https://github.com/grafana/terraform-provider-grafana), to allow referencing the `uid` from the tf resource.

