### PR TITLE
Alerting parameters for datasource JSONData struct

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -95,6 +95,13 @@ type JSONData struct {
 	SigV4ExternalID    string `json:"sigV4ExternalID,omitempty"`
 	SigV4Profile       string `json:"sigV4Profile,omitempty"`
 	SigV4Region        string `json:"sigV4Region,omitempty"`
+
+	// Used by Prometheus and Loki
+	ManageAlerts    bool   `json:"manageAlerts,omitempty"`
+	AlertmanagerUID string `json:"alertmanagerUid,omitempty"`
+
+	// Used by Alertmanager
+	Implementation string `json:"implementation,omitempty"`
 }
 
 // SecureJSONData is a representation of the datasource `secureJsonData` property


### PR DESCRIPTION
This PR adds an ability to disable alerting integration for Prometheus/Loki datasources (added in grafana/grafana#36552), set [Alertmanager datasource](https://grafana.com/docs/grafana/latest/datasources/alertmanager/) and choose implementations for such datasources if this feature is enabled.

This will be used later in Terraform Provider for Grafana.

![image](https://user-images.githubusercontent.com/3420079/147710886-a4f3504e-0fe3-4973-8cc4-022cd5d7e40e.png)
<img width="649" alt="Screenshot 2021-12-30 at 10 24 35" src="https://user-images.githubusercontent.com/3420079/147743365-474e0e01-697a-4670-a08f-6b2c76e97338.png">