### PR TITLE
Adding InfluxDB Flux data source support for terraform-provider-grafana

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -161,6 +161,11 @@ type JSONData struct {
 	// Used by Sentry
 	OrgSlug string `json:"orgSlug,omitempty"`
 	URL     string `json:"url,omitempty"` // Sentry is not using the datasource URL attribute
+
+	// Used by InfluxDB
+	DefaultBucket string `json:"defaultBucket,omitempty"`
+	Organization  string `json:"organization,omitempty"`
+	Version       string `json:"version,omitempty"`
 }
 
 // Required to avoid recursion during (un)marshal
@@ -240,6 +245,9 @@ type SecureJSONData struct {
 
 	// Used by Sentry
 	AuthToken string `json:"authToken,omitempty"`
+
+	// Used by InfluxDB
+	Token string `json:"token,omitempty"`
 }
 
 // Required to avoid recursion during unmarshal

--- a/datasource.go
+++ b/datasource.go
@@ -245,9 +245,6 @@ type SecureJSONData struct {
 
 	// Used by Sentry
 	AuthToken string `json:"authToken,omitempty"`
-
-	// Used by InfluxDB
-	Token string `json:"token,omitempty"`
 }
 
 // Required to avoid recursion during unmarshal

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -149,9 +149,13 @@ func TestNewInfluxDBDataSource(t *testing.T) {
 		URL:       "http://some-url.com",
 		IsDefault: true,
 		JSONData: JSONData{
-			DefaultBucket: "telegraf",
-			Organization:  "acme",
-			Version:       "Flux",
+			DefaultBucket:   "telegraf",
+			httpHeaderNames: []string{"Authorization"},
+			Organization:    "acme",
+			Version:         "Flux",
+		},
+		SecureJSONData: SecureJSONData{
+			httpHeaderValues: []string{"Bearer eyJhbGciOiJIUzI1NiJ9.eyJSb2xlIjoiQWRtaW4iLCJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkphdmFJblVzZSIsImV4cCI6MTY0NDUwNjM3MywiaWF0IjoxNjQ0NTA2MzczfQ.FyYlVnMgzcP3CoNCHf2GFW49Ng_wLQsrXrUdSNGiShU"},
 		},
 	}
 

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -138,3 +138,31 @@ func TestNewElasticsearchDataSource(t *testing.T) {
 		t.Error("datasource creation response should return the created datasource ID")
 	}
 }
+
+func TestNewInfluxDBDataSource(t *testing.T) {
+	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
+	defer server.Close()
+
+	ds := &DataSource{
+		Name:      "foo_influxdb",
+		Type:      "influxdb",
+		URL:       "http://some-url.com",
+		IsDefault: true,
+		JSONData: JSONData{
+			DefaultBucket: "telegraf",
+			Organization:  "acme",
+			Version:       "Flux",
+		},
+	}
+
+	created, err := client.NewDataSource(ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(pretty.PrettyFormat(created))
+
+	if created != 1 {
+		t.Error("datasource creation response should return the created datasource ID")
+	}
+}

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -155,7 +155,7 @@ func TestNewInfluxDBDataSource(t *testing.T) {
 			Version:         "Flux",
 		},
 		SecureJSONData: SecureJSONData{
-			httpHeaderValues: []string{"Bearer eyJhbGciOiJIUzI1NiJ9.eyJSb2xlIjoiQWRtaW4iLCJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkphdmFJblVzZSIsImV4cCI6MTY0NDUwNjM3MywiaWF0IjoxNjQ0NTA2MzczfQ.FyYlVnMgzcP3CoNCHf2GFW49Ng_wLQsrXrUdSNGiShU"},
+			httpHeaderValues: []string{"Token alksdjaslkdjkslajdkj.asdlkjaksdjlkajsdlkjsaldj=="},
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafana/grafana-api-golang-client
+module github.com/abeego/grafana-api-golang-client
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/abeego/grafana-api-golang-client
+module github.com/albeego/grafana-api-golang-client
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/albeego/grafana-api-golang-client
+module github.com/grafana/grafana-api-golang-client
 
 go 1.14
 


### PR DESCRIPTION
Added support for InfluxDB / Flux data sources. I've run this against a grafana instance using the `terraform-provider-grafana` test suite pointed at this fork. It populated a Flux data source and I queried data using it. Please see associated changes here: https://github.com/albeego/terraform-provider-grafana once this is merged I will open the PR for `terraform-provider-grafana`