### PR TITLE
Add provisioning fields to DashboardMeta

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -9,9 +9,11 @@ import (
 
 // DashboardMeta represents Grafana dashboard meta.
 type DashboardMeta struct {
-	IsStarred bool   `json:"isStarred"`
-	Slug      string `json:"slug"`
-	Folder    int64  `json:"folderId"`
+	IsStarred             bool   `json:"isStarred"`
+	Slug                  string `json:"slug"`
+	Folder                int64  `json:"folderId"`
+	Provisioned           bool   `json:"provisioned"`
+	ProvisionedExternalID string `json:"provisionedExternalId"`
 }
 
 // DashboardSaveResponse represents the Grafana API response to creating or saving a dashboard.

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -25,7 +25,9 @@ const (
 		"meta": {
 			"isStarred": false,
 			"url": "/d/cIBgcSjkk/production-overview",
-			"slug": "production-overview"
+			"slug": "production-overview",
+			"provisioned": false,
+			"provisionedExternalId": ""
 		}
 	}`
 


### PR DESCRIPTION
I added the `Provisioned` and `ProvisionedExternalID` fields to the `DashboardMeta` struct so that this information is returned when getting a dashboard from the API. These attributes should help clients avoid trying to update a provisioned dashboard (which results in a HTTP 400 response).