### PR TITLE
RBAC - Add new fields for managing roles

### DIFF
--- a/role.go
+++ b/role.go
@@ -12,6 +12,9 @@ type Role struct {
 	Name        string       `json:"name"`
 	Description string       `json:"description"`
 	Global      bool         `json:"global"`
+	Group       string       `json:"group"`
+	DisplayName string       `json:"string"`
+	Hidden      bool         `json:"hidden"`
 	Permissions []Permission `json:"permissions,omitempty"`
 }
 

--- a/role_test.go
+++ b/role_test.go
@@ -14,6 +14,9 @@ const (
     "name": "test:policy",
 	"version": 1,
     "description": "Test policy description",
+	"displayName": "test display",
+	"group": "test group",
+    "hidden": false,
     "permissions": [
         {
             "id": 6,
@@ -34,6 +37,9 @@ const (
     "name": "test:policy",
 	"version": 1,
     "description": "Test policy description",
+	"displayName": "test display",
+	"group": "test group",
+    "hidden": false,
     "permissions": [
         {
             "permission": "test:self",
@@ -101,6 +107,9 @@ func TestGetRole(t *testing.T) {
 		UID:         "vc3SCSsGz",
 		Name:        "test:policy",
 		Description: "Test policy description",
+		Group:       "test group",
+		DisplayName: "test display",
+		Hidden:      false,
 		Permissions: []Permission{
 			{
 				Action: "test:self",


### PR DESCRIPTION
[Grafana RBAC API](https://grafana.com/docs/grafana/next/http_api/access_control/#create-a-new-custom-role) supports some additional fields which are required to make terraform resource behaviour consistent. 

This PR adds the following fields:
- displayName
- group
- hidden