### PR TITLE
datasource API: add list and find by name functions

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -351,6 +351,32 @@ func (c *Client) DataSourceByUID(uid string) (*DataSource, error) {
 	return result, err
 }
 
+// DataSourceIdByName returns the Grafana data source id by name.
+func (c *Client) DataSourceIdByName(name string) (int64, error) {
+	path := fmt.Sprintf("/api/datasources/id/%s", name)
+
+	result := struct {
+		ID int64 `json:"id"`
+	}{}
+	err := c.request("GET", path, nil, nil, &result)
+	if err != nil {
+		return result.ID, err
+	}
+
+	return result.ID, err
+}
+
+// DataSources returns all data sources as defined in Grafana.
+func (c *Client) DataSources() ([]*DataSource, error) {
+	result := make([]*DataSource, 0)
+	err := c.request("GET", "/api/datasources", nil, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // DeleteDataSource deletes the Grafana data source whose ID it's passed.
 func (c *Client) DeleteDataSource(id int64) error {
 	path := fmt.Sprintf("/api/datasources/%d", id)

--- a/datasource.go
+++ b/datasource.go
@@ -351,8 +351,8 @@ func (c *Client) DataSourceByUID(uid string) (*DataSource, error) {
 	return result, err
 }
 
-// DataSourceIdByName returns the Grafana data source id by name.
-func (c *Client) DataSourceIdByName(name string) (int64, error) {
+// DataSourceIDByName returns the Grafana data source ID by name.
+func (c *Client) DataSourceIDByName(name string) (int64, error) {
 	path := fmt.Sprintf("/api/datasources/id/%s", name)
 
 	result := struct {

--- a/datasource.go
+++ b/datasource.go
@@ -358,12 +358,13 @@ func (c *Client) DataSourceIDByName(name string) (int64, error) {
 	result := struct {
 		ID int64 `json:"id"`
 	}{}
+
 	err := c.request("GET", path, nil, nil, &result)
 	if err != nil {
-		return result.ID, err
+		return 0, err
 	}
 
-	return result.ID, err
+	return result.ID, nil
 }
 
 // DataSources returns all data sources as defined in Grafana.

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -257,16 +257,16 @@ func TestDataSources(t *testing.T) {
 	}
 }
 
-func TestDataSourceIdByName(t *testing.T) {
+func TestDataSourceIDByName(t *testing.T) {
 	server, client := gapiTestTools(t, 200, getDataSourceJSON)
 	defer server.Close()
 
-	datasourceId, err := client.DataSourceIdByName("foo")
+	datasourceID, err := client.DataSourceIDByName("foo")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if datasourceId != 1 {
+	if datasourceID != 1 {
 		t.Error("Not correctly parsing returned datasources.")
 	}
 }

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -8,8 +8,8 @@ import (
 
 const (
 	createdDataSourceJSON = `{"id":1,"uid":"myuid0001","message":"Datasource added", "name": "test_datasource"}`
-	getDataSourceJSON = `{"id":1}`
-	getDataSourcesJSON = `[{"id":1,"name":"foo","type":"cloudwatch","url":"http://some-url.com","access":"access","isDefault":true}]`
+	getDataSourceJSON     = `{"id":1}`
+	getDataSourcesJSON    = `[{"id":1,"name":"foo","type":"cloudwatch","url":"http://some-url.com","access":"access","isDefault":true}]`
 )
 
 func TestNewDataSource(t *testing.T) {

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -8,6 +8,8 @@ import (
 
 const (
 	createdDataSourceJSON = `{"id":1,"uid":"myuid0001","message":"Datasource added", "name": "test_datasource"}`
+	getDataSourceJSON = `{"id":1}`
+	getDataSourcesJSON = `[{"id":1,"name":"foo","type":"cloudwatch","url":"http://some-url.com","access":"access","isDefault":true}]`
 )
 
 func TestNewDataSource(t *testing.T) {
@@ -233,5 +235,38 @@ func TestNewAzureDataSource(t *testing.T) {
 
 	if created != 1 {
 		t.Error("datasource creation response should return the created datasource ID")
+	}
+}
+
+func TestDataSources(t *testing.T) {
+	server, client := gapiTestTools(t, 200, getDataSourcesJSON)
+	defer server.Close()
+
+	datasources, err := client.DataSources()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(pretty.PrettyFormat(datasources))
+
+	if len(datasources) != 1 {
+		t.Error("Length of returned datasources should be 1")
+	}
+	if datasources[0].ID != 1 || datasources[0].Name != "foo" {
+		t.Error("Not correctly parsing returned datasources.")
+	}
+}
+
+func TestDataSourceIdByName(t *testing.T) {
+	server, client := gapiTestTools(t, 200, getDataSourceJSON)
+	defer server.Close()
+
+	datasourceId, err := client.DataSourceIdByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if datasourceId != 1 {
+		t.Error("Not correctly parsing returned datasources.")
 	}
 }


### PR DESCRIPTION
Currently the only way to find a datasource is by it's id which is not available most of the times. 
This PR adds two lookup methods for datasources:
- DataSourceIdByName - retrieve datasource id by name
- DataSource - retrieve all datasources of an organization

