### PR TITLE
add GAPIError to allow custom error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-cleanhttp"
 	"io"
 	"io/ioutil"
 	"log"
@@ -14,6 +13,8 @@ import (
 	"path"
 	"strconv"
 	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 // Client is a Grafana API client.

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/go-cleanhttp"
 	"io"
 	"io/ioutil"
 	"log"
@@ -13,8 +14,6 @@ import (
 	"path"
 	"strconv"
 	"time"
-
-	"github.com/hashicorp/go-cleanhttp"
 )
 
 // Client is a Grafana API client.
@@ -117,7 +116,7 @@ func (c *Client) request(method, requestPath string, query url.Values, body io.R
 
 	// check status code.
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("status: %d, body: %v", resp.StatusCode, string(bodyContents))
+		return &GApiError{statusCode: resp.StatusCode, message: string(bodyContents)}
 	}
 
 	if responseStruct == nil {

--- a/error.go
+++ b/error.go
@@ -7,12 +7,12 @@ import (
 
 type GApiError struct {
 	statusCode int
-	message string
+	message    string
 }
 
 // Error implements the error interface.
 func (e *GApiError) Error() string {
-	return fmt.Sprintf("status: %d, body: %v", e.statusCode, string(e.message))
+	return fmt.Sprintf("status: %d, body: %v", e.statusCode, e.message)
 }
 
 // IsNotFound returns a boolean indicating whether the error is a not found error.

--- a/error.go
+++ b/error.go
@@ -1,0 +1,47 @@
+package gapi
+
+import (
+	"errors"
+	"fmt"
+)
+
+type GApiError struct {
+	statusCode int
+	message string
+}
+
+// Error implements the error interface.
+func (e *GApiError) Error() string {
+	return fmt.Sprintf("status: %d, body: %v", e.statusCode, string(e.message))
+}
+
+// IsNotFound returns a boolean indicating whether the error is a not found error.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var e *GApiError
+	if errors.As(err, &e) && e.statusCode == 404 {
+		return true
+	}
+	return false
+}
+
+func GetGApiError(err error) *GApiError {
+	if err == nil {
+		return nil
+	}
+	var e *GApiError
+	if errors.As(err, &e) {
+		return e
+	}
+	return nil
+}
+
+func (e *GApiError) StatusCode() int {
+	return e.statusCode
+}
+
+func (e *GApiError) Message() string {
+	return e.message
+}

--- a/error_test.go
+++ b/error_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	someErrorJSON = `{"message":"some unknown error occured"}`
+	someErrorJSON          = `{"message":"some unknown error occurred"}`
 	dataSourceNotFoundJSON = `{"message":"datasource not found"}`
 )
 
@@ -14,8 +14,8 @@ func TestGAPIError(t *testing.T) {
 	defer server.Close()
 
 	_, err := client.DataSource(100)
-	gapiErr := GetGApiError(err);
-	if  gapiErr == nil {
+	gapiErr := GetGApiError(err)
+	if gapiErr == nil {
 		t.Fatal("Error should be a GApiError")
 	}
 	if gapiErr.StatusCode() != 500 {

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,38 @@
+package gapi
+
+import (
+	"testing"
+)
+
+const (
+	someErrorJSON = `{"message":"some unknown error occured"}`
+	dataSourceNotFoundJSON = `{"message":"datasource not found"}`
+)
+
+func TestGAPIError(t *testing.T) {
+	server, client := gapiTestTools(t, 500, someErrorJSON)
+	defer server.Close()
+
+	_, err := client.DataSource(100)
+	gapiErr := GetGApiError(err);
+	if  gapiErr == nil {
+		t.Fatal("Error should be a GApiError")
+	}
+	if gapiErr.StatusCode() != 500 {
+		t.Error("Error status code should be 500")
+	}
+
+	if gapiErr.Message() != someErrorJSON {
+		t.Errorf("Error message should be %s", someErrorJSON)
+	}
+}
+
+func TestIsNotFoundError(t *testing.T) {
+	server, client := gapiTestTools(t, 404, dataSourceNotFoundJSON)
+	defer server.Close()
+
+	_, err := client.DataSource(100)
+	if !IsNotFound(err) {
+		t.Fatal("Error should be a GApiError")
+	}
+}


### PR DESCRIPTION
Currently there is no way to check for error codes.
This PR adds a specific GApiError so that error messages and status codes can be checked and a specofoc method IsNotFound to check for the most often 404 errors.