### PR TITLE
Fix the displayName json representation for Grafana role

### DIFF
--- a/role.go
+++ b/role.go
@@ -13,7 +13,7 @@ type Role struct {
 	Description string       `json:"description"`
 	Global      bool         `json:"global"`
 	Group       string       `json:"group"`
-	DisplayName string       `json:"string"`
+	DisplayName string       `json:"displayName"`
 	Hidden      bool         `json:"hidden"`
 	Permissions []Permission `json:"permissions,omitempty"`
 }


### PR DESCRIPTION
This was an error which I have missed in previous PRs. Without this fix, the Grafana will receive an empty display name and result to inconsistent and wrong experience.