### PR TITLE
Alerting: Add support for Unified Alerting message templates

### DIFF
--- a/alerting_message_template.go
+++ b/alerting_message_template.go
@@ -34,16 +34,16 @@ func (c *Client) MessageTemplate(name string) (*AlertingMessageTemplate, error) 
 }
 
 // SetMessageTemplate creates or updates a message template.
-func (c *Client) SetMessageTemplate(t *AlertingMessageTemplate) error {
+func (c *Client) SetMessageTemplate(name, content string) error {
 	req := struct {
 		Template string `json:"template"`
-	}{Template: t.Template}
+	}{Template: content}
 	body, err := json.Marshal(req)
 	if err != nil {
 		return err
 	}
 
-	uri := fmt.Sprintf("/api/v1/provisioning/templates/%s", t.Name)
+	uri := fmt.Sprintf("/api/v1/provisioning/templates/%s", name)
 	return c.request("PUT", uri, nil, bytes.NewBuffer(body), nil)
 }
 

--- a/alerting_message_template.go
+++ b/alerting_message_template.go
@@ -1,0 +1,54 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// AlertingMessageTemplate is a re-usable template for Grafana Alerting messages.
+type AlertingMessageTemplate struct {
+	Name     string `json:"name"`
+	Template string `json:"template"`
+}
+
+// MessageTemplates fetches all message templates.
+func (c *Client) MessageTemplates() ([]AlertingMessageTemplate, error) {
+	ts := make([]AlertingMessageTemplate, 0)
+	err := c.request("GET", "/api/v1/provisioning/templates", nil, nil, &ts)
+	if err != nil {
+		return nil, err
+	}
+	return ts, nil
+}
+
+// MessageTemplate fetches a single message template, identified by its name.
+func (c *Client) MessageTemplate(name string) (*AlertingMessageTemplate, error) {
+	t := AlertingMessageTemplate{}
+	uri := fmt.Sprintf("/api/v1/provisioning/templates/%s", name)
+	err := c.request("GET", uri, nil, nil, &t)
+	if err != nil {
+		return nil, err
+	}
+	return &t, err
+}
+
+// SetMessageTemplate creates or updates a message template.
+func (c *Client) SetMessageTemplate(t *AlertingMessageTemplate) error {
+	req := struct {
+		Template string `json:"template"`
+	}{Template: t.Template}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	uri := fmt.Sprintf("/api/v1/provisioning/templates/%s", t.Name)
+	return c.request("PUT", uri, nil, bytes.NewBuffer(body), nil)
+}
+
+// DeleteMessageTemplate deletes a message template.
+func (c *Client) DeleteMessageTemplate(name string) error {
+	uri := fmt.Sprintf("/api/v1/provisioning/templates/%s", name)
+	return c.request("DELETE", uri, nil, nil, nil)
+}

--- a/alerting_message_template_test.go
+++ b/alerting_message_template_test.go
@@ -1,0 +1,99 @@
+package gapi
+
+import (
+	"testing"
+
+	"github.com/gobs/pretty"
+)
+
+func TestMessageTemplates(t *testing.T) {
+	t.Run("get message templates succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 200, getMessageTemplatesJSON)
+		defer server.Close()
+
+		ts, err := client.MessageTemplates()
+
+		if err != nil {
+			t.Error(err)
+		}
+		t.Log(pretty.PrettyFormat(ts))
+		if len(ts) != 2 {
+			t.Errorf("wrong number of templates returned, got %#v", ts)
+		}
+		if ts[0].Name != "template-one" {
+			t.Errorf("incorrect name - expected %s on element %d, got %#v", "template-one", 0, ts)
+		}
+		if ts[1].Name != "template-two" {
+			t.Errorf("incorrect name - expected %s on element %d, got %#v", "template-two", 0, ts)
+		}
+	})
+
+	t.Run("get message template succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 200, messageTemplateJSON)
+		defer server.Close()
+
+		tmpl, err := client.MessageTemplate("template-one")
+
+		if err != nil {
+			t.Error(err)
+		}
+		t.Log(pretty.PrettyFormat(tmpl))
+		if tmpl.Name != "template-one" {
+			t.Errorf("incorrect name - expected %s, got %#v", "template-one", tmpl)
+		}
+	})
+
+	t.Run("get non-existent message template fails", func(t *testing.T) {
+		server, client := gapiTestTools(t, 404, ``)
+		defer server.Close()
+
+		tmpl, err := client.MessageTemplate("does not exist")
+
+		if err == nil {
+			t.Errorf("expected error but got nil")
+			t.Log(pretty.PrettyFormat(tmpl))
+		}
+	})
+
+	t.Run("put message template succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 202, messageTemplateJSON)
+		defer server.Close()
+
+		err := client.SetMessageTemplate("template-three", "{{define \"template-one\" }}\n  content three\n{{ end }}")
+
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("delete message template succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 204, ``)
+		defer server.Close()
+
+		err := client.DeleteMessageTemplate("template-three")
+
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+const getMessageTemplatesJSON = `
+[
+	{
+		"name": "template-one",
+		"template": "{{define \"template-one\" }}\n  content one\n{{ end }}"
+	},
+	{
+		"name": "template-two",
+		"template": "{{define \"template-one\" }}\n  content two\n{{ end }}"
+	}
+]
+`
+
+const messageTemplateJSON = `
+{
+	"name": "template-one",
+	"template": "{{define \"template-one\" }}\n  content one\n{{ end }}"
+}
+`


### PR DESCRIPTION
Implements support for the message template resource in Unified Alerting. The Grafana Terraform provider will consume these new APIs in a future PR.