### PR TITLE
Revert "RBAC - Remove built-in role assignments client"

### DIFF
--- a/builtin_role_assignments.go
+++ b/builtin_role_assignments.go
@@ -1,0 +1,58 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+const baseURL = "/api/access-control/builtin-roles"
+
+type BuiltInRoleAssignment struct {
+	BuiltinRole string `json:"builtInRole"`
+	RoleUID     string `json:"roleUid"`
+	Global      bool   `json:"global"`
+}
+
+// GetBuiltInRoleAssignments gets all built-in role assignments. Available only in Grafana Enterprise 8.+.
+func (c *Client) GetBuiltInRoleAssignments() (map[string][]*Role, error) {
+	br := make(map[string][]*Role)
+	err := c.request("GET", baseURL, nil, nil, &br)
+	if err != nil {
+		return nil, err
+	}
+	return br, nil
+}
+
+// NewBuiltInRoleAssignment creates a new built-in role assignment. Available only in Grafana Enterprise 8.+.
+func (c *Client) NewBuiltInRoleAssignment(builtInRoleAssignment BuiltInRoleAssignment) (*BuiltInRoleAssignment, error) {
+	body, err := json.Marshal(builtInRoleAssignment)
+	if err != nil {
+		return nil, err
+	}
+
+	br := &BuiltInRoleAssignment{}
+
+	err = c.request("POST", baseURL, nil, bytes.NewBuffer(body), &br)
+	if err != nil {
+		return nil, err
+	}
+
+	return br, err
+}
+
+// DeleteBuiltInRoleAssignment remove the built-in role assignments. Available only in Grafana Enterprise 8.+.
+func (c *Client) DeleteBuiltInRoleAssignment(builtInRole BuiltInRoleAssignment) error {
+	data, err := json.Marshal(builtInRole)
+	if err != nil {
+		return err
+	}
+
+	qp := map[string][]string{
+		"global": {fmt.Sprint(builtInRole.Global)},
+	}
+	url := fmt.Sprintf("%s/%s/roles/%s", baseURL, builtInRole.BuiltinRole, builtInRole.RoleUID)
+	err = c.request("DELETE", url, qp, bytes.NewBuffer(data), nil)
+
+	return err
+}

--- a/builtin_role_assignments_test.go
+++ b/builtin_role_assignments_test.go
@@ -1,0 +1,114 @@
+package gapi
+
+import (
+	"testing"
+)
+
+const (
+	newBuiltInRoleAssignmentResponse = `
+{
+    "message": "Built-in role grant added"
+}
+`
+	getBuiltInRoleAssignmentsResponse = `
+{
+    "Grafana Admin": [
+        {
+            "version": 1,
+            "uid": "tJTyTNqMk",
+            "name": "grafana:roles:users:admin:read",
+            "description": "",
+            "global": true
+        }
+    ],
+    "Viewer": [
+        {
+            "version": 2,
+            "uid": "tJTyTNqMk1",
+            "name": "custom:reports:editor",
+            "description": "Role to allow users to create/read reports",
+            "global": false
+        }
+    ]
+}
+`
+
+	removeBuiltInRoleAssignmentResponse = `
+{
+    "message": "Built-in role grant removed"
+}
+`
+)
+
+func TestNewBuiltInRoleAssignment(t *testing.T) {
+	server, client := gapiTestTools(t, 200, newBuiltInRoleAssignmentResponse)
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	br := BuiltInRoleAssignment{
+		Global:      false,
+		RoleUID:     "test:policy",
+		BuiltinRole: "Viewer",
+	}
+
+	_, err := client.NewBuiltInRoleAssignment(br)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetBuiltInRoleAssignments(t *testing.T) {
+	server, client := gapiTestTools(t, 200, getBuiltInRoleAssignmentsResponse)
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	resp, err := client.GetBuiltInRoleAssignments()
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := map[string][]*Role{
+		"Grafana Admin": {
+			{
+				Version:     1,
+				Global:      true,
+				Name:        "grafana:roles:users:admin:read",
+				UID:         "tJTyTNqMk",
+				Description: "",
+			},
+		},
+		"Viewer": {
+			{
+				Version:     2,
+				Global:      false,
+				Name:        "custom:reports:editor",
+				UID:         "tJTyTNqMk1",
+				Description: "Role to allow users to create/read reports",
+			},
+		},
+	}
+
+	if len(expected["Viewer"]) != len(resp["Viewer"]) || len(expected["Grafana Admin"]) != len(resp["Grafana Admin"]) {
+		t.Error("Unexpected built-in role assignments.")
+	}
+}
+
+func TestDeleteBuiltInRoleAssignment(t *testing.T) {
+	server, client := gapiTestTools(t, 200, removeBuiltInRoleAssignmentResponse)
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	br := BuiltInRoleAssignment{
+		Global:      false,
+		RoleUID:     "test:policy",
+		BuiltinRole: "Viewer",
+	}
+	err := client.DeleteBuiltInRoleAssignment(br)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Reverts grafana/grafana-api-golang-client#79 as we have decided to keep the resource as deprecated/not working for now. If we remove the gapi client, the provider won't even compile