### PR TITLE
Alerting: Add support for Unified Alerting mute timings

### DIFF
--- a/alerting_mute_timing.go
+++ b/alerting_mute_timing.go
@@ -1,6 +1,10 @@
 package gapi
 
-import "fmt"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
 
 // MuteTiming represents a Grafana Alerting mute timing.
 type MuteTiming struct {
@@ -52,4 +56,31 @@ func (c *Client) MuteTiming(name string) (MuteTiming, error) {
 	uri := fmt.Sprintf("/api/v1/provisioning/mute-timings/%s", name)
 	err := c.request("GET", uri, nil, nil, &mt)
 	return mt, err
+}
+
+// NewMuteTiming creates a new mute timing.
+func (c *Client) NewMuteTiming(mt *MuteTiming) error {
+	req, err := json.Marshal(mt)
+	if err != nil {
+		return err
+	}
+
+	return c.request("POST", "/api/v1/provisioning/mute-timings", nil, bytes.NewBuffer(req), nil)
+}
+
+// UpdateMuteTiming updates a mute timing.
+func (c *Client) UpdateMuteTiming(mt *MuteTiming) error {
+	uri := fmt.Sprintf("/api/v1/provisioning/mute-timings/%s", mt.Name)
+	req, err := json.Marshal(mt)
+	if err != nil {
+		return err
+	}
+
+	return c.request("PUT", uri, nil, bytes.NewBuffer(req), nil)
+}
+
+// DeleteMutetiming deletes a mute timing.
+func (c *Client) DeleteMuteTiming(name string) error {
+	uri := fmt.Sprintf("/api/v1/provisioning/mute-timings/%s", name)
+	return c.request("DELETE", uri, nil, nil, nil)
 }

--- a/alerting_mute_timing.go
+++ b/alerting_mute_timing.go
@@ -22,31 +22,17 @@ type TimeRange struct {
 	EndMinute   int
 }
 
-// A WeekdayRange is an inclusive range between [0, 6] where 0 = Sunday.
-type WeekdayRange struct {
-	InclusiveRange
-}
+// A WeekdayRange is an inclusive range of weekdays, e.g. "monday" or "tuesday:thursday".
+type WeekdayRange string
 
-// A DayOfMonthRange is an inclusive range that may have negative Beginning/End values that represent distance from the End of the month Beginning at -1.
-type DayOfMonthRange struct {
-	InclusiveRange
-}
+// A DayOfMonthRange is an inclusive range of days, 1-31, within a month, e.g. "1" or "14:16". Negative values can be used to represent days counting from the end of a month, e.g. "-1".
+type DayOfMonthRange string
 
-// A MonthRange is an inclusive range between [1, 12] where 1 = January.
-type MonthRange struct {
-	InclusiveRange
-}
+// A MonthRange is an inclusive range of months, either numerical or full calendar month, e.g "1:3", "december", or "may:august".
+type MonthRange string
 
-// A YearRange is a positive inclusive range.
-type YearRange struct {
-	InclusiveRange
-}
-
-// InclusiveRange is used to hold the Beginning and End values of many time interval components.
-type InclusiveRange struct {
-	Begin int
-	End   int
-}
+// A YearRange is a positive inclusive range of years, e.g. "2030" or "2021:2022".
+type YearRange string
 
 func (c *Client) MuteTimings() ([]MuteTiming, error) {
 	mts := make([]MuteTiming, 0)

--- a/alerting_mute_timing.go
+++ b/alerting_mute_timing.go
@@ -1,5 +1,7 @@
 package gapi
 
+import "fmt"
+
 // MuteTiming represents a Grafana Alerting mute timing.
 type MuteTiming struct {
 	Name          string         `json:"name"`
@@ -34,6 +36,7 @@ type MonthRange string
 // A YearRange is a positive inclusive range of years, e.g. "2030" or "2021:2022".
 type YearRange string
 
+// MuteTimings fetches all mute timings.
 func (c *Client) MuteTimings() ([]MuteTiming, error) {
 	mts := make([]MuteTiming, 0)
 	err := c.request("GET", "/api/v1/provisioning/mute-timings", nil, nil, &mts)
@@ -41,4 +44,12 @@ func (c *Client) MuteTimings() ([]MuteTiming, error) {
 		return nil, err
 	}
 	return mts, nil
+}
+
+// MuteTiming fetches a single mute timing, identified by its name.
+func (c *Client) MuteTiming(name string) (MuteTiming, error) {
+	mt := MuteTiming{}
+	uri := fmt.Sprintf("/api/v1/provisioning/mute-timings/%s", name)
+	err := c.request("GET", uri, nil, nil, &mt)
+	return mt, err
 }

--- a/alerting_mute_timing.go
+++ b/alerting_mute_timing.go
@@ -1,0 +1,58 @@
+package gapi
+
+// MuteTiming represents a Grafana Alerting mute timing.
+type MuteTiming struct {
+	Name          string         `json:"name"`
+	TimeIntervals []TimeInterval `json:"time_intervals"`
+	Provenance    string         `json:"provenance,omitempty"`
+}
+
+// TimeInterval describes intervals of time using a Prometheus-defined standard.
+type TimeInterval struct {
+	Times       []TimeRange       `json:"times,omitempty"`
+	Weekdays    []WeekdayRange    `json:"weekdays,omitempty"`
+	DaysOfMonth []DayOfMonthRange `json:"days_of_month,omitempty"`
+	Months      []MonthRange      `json:"months,omitempty"`
+	Years       []YearRange       `json:"years,omitempty"`
+}
+
+// TimeRange represents a range of minutes within a 1440 minute day, exclusive of the End minute.
+type TimeRange struct {
+	StartMinute int
+	EndMinute   int
+}
+
+// A WeekdayRange is an inclusive range between [0, 6] where 0 = Sunday.
+type WeekdayRange struct {
+	InclusiveRange
+}
+
+// A DayOfMonthRange is an inclusive range that may have negative Beginning/End values that represent distance from the End of the month Beginning at -1.
+type DayOfMonthRange struct {
+	InclusiveRange
+}
+
+// A MonthRange is an inclusive range between [1, 12] where 1 = January.
+type MonthRange struct {
+	InclusiveRange
+}
+
+// A YearRange is a positive inclusive range.
+type YearRange struct {
+	InclusiveRange
+}
+
+// InclusiveRange is used to hold the Beginning and End values of many time interval components.
+type InclusiveRange struct {
+	Begin int
+	End   int
+}
+
+func (c *Client) MuteTimings() ([]MuteTiming, error) {
+	mts := make([]MuteTiming, 0)
+	err := c.request("GET", "/api/v1/provisioning/mute-timings", nil, nil, &mts)
+	if err != nil {
+		return nil, err
+	}
+	return mts, nil
+}

--- a/alerting_mute_timing_test.go
+++ b/alerting_mute_timing_test.go
@@ -1,0 +1,71 @@
+package gapi
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/gobs/pretty"
+)
+
+func TestMuteTimings(t *testing.T) {
+	t.Run("get mute timings succeeds", func(t *testing.T) {
+		/*server, client := gapiTestTools(t, 200, getMessageTemplatesJSON)
+		defer server.Close()*/
+		cfg := Config{
+			BasicAuth: url.UserPassword("admin", "admin"),
+		}
+		client, _ := New("http://localhost:3000", cfg)
+
+		mts, err := client.MuteTimings()
+
+		if err != nil {
+			t.Error(err)
+		}
+		t.Log(pretty.PrettyFormat(mts))
+		if len(mts) != 2 {
+			t.Errorf("wrong number of mute timings returned, got %#v", mts)
+		}
+		if mts[0].Name != "timing one" {
+			t.Errorf("incorrect name - expected %s on element %d, got %#v", "timing one", 0, mts)
+		}
+		if mts[1].Name != "another timing" {
+			t.Errorf("incorrect name - expected %s on element %d, got %#v", "another timing", 1, mts)
+		}
+	})
+}
+
+const getMuteTimingsJSON = `
+[
+	{
+		"name": "timing one",
+		"time_intervals": [
+			{
+				"times": [
+					{
+						"start_time": "13:13",
+						"end_time": "15:15"
+					}
+				],
+				"weekdays": [
+					"monday:wednesday"
+				],
+				"months": [
+					"1"
+				]
+			}
+		]
+	},
+	{
+		"name": "another timing",
+		"time_intervals": [
+			{
+				"days_of_month": [
+					"1"
+				],
+				"years": [
+					"2030"
+				]
+			}
+		]
+	}
+]`

--- a/alerting_mute_timing_test.go
+++ b/alerting_mute_timing_test.go
@@ -1,7 +1,6 @@
 package gapi
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/gobs/pretty"
@@ -9,12 +8,8 @@ import (
 
 func TestMuteTimings(t *testing.T) {
 	t.Run("get mute timings succeeds", func(t *testing.T) {
-		/*server, client := gapiTestTools(t, 200, getMessageTemplatesJSON)
-		defer server.Close()*/
-		cfg := Config{
-			BasicAuth: url.UserPassword("admin", "admin"),
-		}
-		client, _ := New("http://localhost:3000", cfg)
+		server, client := gapiTestTools(t, 200, getMuteTimingsJSON)
+		defer server.Close()
 
 		mts, err := client.MuteTimings()
 
@@ -30,6 +25,37 @@ func TestMuteTimings(t *testing.T) {
 		}
 		if mts[1].Name != "another timing" {
 			t.Errorf("incorrect name - expected %s on element %d, got %#v", "another timing", 1, mts)
+		}
+	})
+
+	t.Run("get mute timing succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 200, muteTimingJSON)
+		defer server.Close()
+
+		mt, err := client.MuteTiming("timing one")
+
+		if err != nil {
+			t.Error(err)
+		}
+		t.Log(pretty.PrettyFormat(mt))
+		if mt.Name != "timing one" {
+			t.Errorf("incorrect name - expected %s, got %#v", "timing one", mt)
+		}
+	})
+
+	t.Run("get non-existent mute timing fails", func(t *testing.T) {
+		server, client := gapiTestTools(t, 404, muteTimingJSON)
+		defer server.Close()
+		/*cfg := Config{
+			BasicAuth: url.UserPassword("admin", "admin"),
+		}
+		client, _ := New("http://localhost:3000", cfg)*/
+
+		mt, err := client.MuteTiming("does not exist")
+
+		if err == nil {
+			t.Errorf("expected error but got nil")
+			t.Log(pretty.PrettyFormat(mt))
 		}
 	})
 }
@@ -69,3 +95,24 @@ const getMuteTimingsJSON = `
 		]
 	}
 ]`
+
+const muteTimingJSON = `
+{
+	"name": "timing one",
+	"time_intervals": [
+		{
+			"times": [
+				{
+					"start_time": "13:13",
+					"end_time": "15:15"
+				}
+			],
+			"weekdays": [
+				"monday:wednesday"
+			],
+			"months": [
+				"1"
+			]
+		}
+	]
+}`

--- a/alerting_mute_timing_test.go
+++ b/alerting_mute_timing_test.go
@@ -46,10 +46,6 @@ func TestMuteTimings(t *testing.T) {
 	t.Run("get non-existent mute timing fails", func(t *testing.T) {
 		server, client := gapiTestTools(t, 404, muteTimingJSON)
 		defer server.Close()
-		/*cfg := Config{
-			BasicAuth: url.UserPassword("admin", "admin"),
-		}
-		client, _ := New("http://localhost:3000", cfg)*/
 
 		mt, err := client.MuteTiming("does not exist")
 
@@ -58,6 +54,55 @@ func TestMuteTimings(t *testing.T) {
 			t.Log(pretty.PrettyFormat(mt))
 		}
 	})
+
+	t.Run("create mute timing succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 201, muteTimingJSON)
+		defer server.Close()
+		mt := createMuteTiming()
+
+		err := client.NewMuteTiming(&mt)
+
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("update mute timing succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 200, muteTimingJSON)
+		defer server.Close()
+		mt := createMuteTiming()
+		mt.TimeIntervals[0].Weekdays = []WeekdayRange{"tuesday", "thursday"}
+
+		err := client.UpdateMuteTiming(&mt)
+
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("delete mute timing succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 204, muteTimingJSON)
+		defer server.Close()
+
+		err := client.DeleteMuteTiming("timing two")
+
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func createMuteTiming() MuteTiming {
+	return MuteTiming{
+		Name: "timing two",
+		TimeIntervals: []TimeInterval{
+			{
+				Weekdays: []WeekdayRange{"monday", "wednesday"},
+				Months:   []MonthRange{"1:3", "4"},
+				Years:    []YearRange{"2022", "2023"},
+			},
+		},
+	}
 }
 
 const getMuteTimingsJSON = `


### PR DESCRIPTION
Implements support for the mute timing resource in Unified Alerting. The Grafana Terraform provider will consume these new APIs in a future PR.