### PR TITLE
Alerting: Add support for Unified Alerting notification policies

### DIFF
--- a/alerting_notification_policy.go
+++ b/alerting_notification_policy.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"time"
 )
 
 // Represents a notification routing tree in Grafana Alerting.
@@ -12,9 +11,9 @@ type NotificationPolicy struct {
 	Receiver       string           `json:"receiver,omitempty"`
 	GroupBy        []string         `json:"group_by,omitempty"`
 	Routes         []SpecificPolicy `json:"routes,omitempty"`
-	GroupWait      time.Duration    `json:"group_wait,omitempty"`
-	GroupInterval  time.Duration    `json:"group_interval,omitempty"`
-	RepeatInterval time.Duration    `json:"repeat_interval,omitempty"`
+	GroupWait      string           `json:"group_wait,omitempty"`
+	GroupInterval  string           `json:"group_interval,omitempty"`
+	RepeatInterval string           `json:"repeat_interval,omitempty"`
 	Provenance     string           `json:"provenance,omitempty"`
 }
 
@@ -26,9 +25,9 @@ type SpecificPolicy struct {
 	MuteTimeIntervals []string         `json:"mute_time_intervals,omitempty"`
 	Continue          bool             `json:"continue"`
 	Routes            []SpecificPolicy `json:"routes,omitempty"`
-	GroupWait         time.Duration    `json:"group_wait,omitempty"`
-	GroupInterval     time.Duration    `json:"group_interval,omitempty"`
-	RepeatInterval    time.Duration    `json:"repeat_interval,omitempty"`
+	GroupWait         string           `json:"group_wait,omitempty"`
+	GroupInterval     string           `json:"group_interval,omitempty"`
+	RepeatInterval    string           `json:"repeat_interval,omitempty"`
 }
 
 type Matchers []Matcher
@@ -110,4 +109,10 @@ func (m Matchers) MarshalJSON() ([]byte, error) {
 		result[i] = [3]string{matcher.Name, matcher.Type.String(), matcher.Value}
 	}
 	return json.Marshal(result)
+}
+
+func (c *Client) NotificationPolicy() (NotificationPolicy, error) {
+	np := NotificationPolicy{}
+	err := c.request("GET", "/api/v1/provisioning/policies", nil, nil, &np)
+	return np, err
 }

--- a/alerting_notification_policy.go
+++ b/alerting_notification_policy.go
@@ -1,0 +1,113 @@
+package gapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+// Represents a notification routing tree in Grafana Alerting.
+type NotificationPolicy struct {
+	Receiver       string           `json:"receiver,omitempty"`
+	GroupBy        []string         `json:"group_by,omitempty"`
+	Routes         []SpecificPolicy `json:"routes,omitempty"`
+	GroupWait      time.Duration    `json:"group_wait,omitempty"`
+	GroupInterval  time.Duration    `json:"group_interval,omitempty"`
+	RepeatInterval time.Duration    `json:"repeat_interval,omitempty"`
+	Provenance     string           `json:"provenance,omitempty"`
+}
+
+// Represents a non-root node in a notification routing tree.
+type SpecificPolicy struct {
+	Receiver          string           `json:"receiver,omitempty"`
+	GroupBy           []string         `json:"group_by,omitempty"`
+	ObjectMatchers    Matchers         `json:"object_matchers,omitempty"`
+	MuteTimeIntervals []string         `json:"mute_time_intervals,omitempty"`
+	Continue          bool             `json:"continue"`
+	Routes            []SpecificPolicy `json:"routes,omitempty"`
+	GroupWait         time.Duration    `json:"group_wait,omitempty"`
+	GroupInterval     time.Duration    `json:"group_interval,omitempty"`
+	RepeatInterval    time.Duration    `json:"repeat_interval,omitempty"`
+}
+
+type Matchers []Matcher
+
+type Matcher struct {
+	Type  MatchType
+	Name  string
+	Value string
+	re    *regexp.Regexp
+}
+
+type MatchType int
+
+const (
+	MatchEqual MatchType = iota
+	MatchNotEqual
+	MatchRegexp
+	MatchNotRegexp
+)
+
+func (m MatchType) String() string {
+	typeToStr := map[MatchType]string{
+		MatchEqual:     "=",
+		MatchNotEqual:  "!=",
+		MatchRegexp:    "=~",
+		MatchNotRegexp: "!~",
+	}
+	if str, ok := typeToStr[m]; ok {
+		return str
+	}
+	panic("unknown match type")
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Matchers.
+func (m *Matchers) UnmarshalJSON(data []byte) error {
+	var rawMatchers [][3]string
+	if err := json.Unmarshal(data, &rawMatchers); err != nil {
+		return err
+	}
+	for _, rawMatcher := range rawMatchers {
+		var matchType MatchType
+		switch rawMatcher[1] {
+		case "=":
+			matchType = MatchEqual
+		case "!=":
+			matchType = MatchNotEqual
+		case "=~":
+			matchType = MatchRegexp
+		case "!~":
+			matchType = MatchNotRegexp
+		default:
+			return fmt.Errorf("unsupported match type %q in matcher", rawMatcher[1])
+		}
+
+		matcher := Matcher{
+			Type:  matchType,
+			Name:  rawMatcher[0],
+			Value: rawMatcher[2],
+		}
+		if matchType == MatchRegexp || matchType == MatchNotRegexp {
+			re, err := regexp.Compile("^(?:" + rawMatcher[2] + ")$")
+			if err != nil {
+				return err
+			}
+			matcher.re = re
+		}
+		*m = append(*m, matcher)
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for Matchers.
+func (m Matchers) MarshalJSON() ([]byte, error) {
+	if len(m) == 0 {
+		return nil, nil
+	}
+	result := make([][3]string, len(m))
+	for i, matcher := range m {
+		result[i] = [3]string{matcher.Name, matcher.Type.String(), matcher.Value}
+	}
+	return json.Marshal(result)
+}

--- a/alerting_notification_policy_test.go
+++ b/alerting_notification_policy_test.go
@@ -1,0 +1,59 @@
+package gapi
+
+import (
+	"testing"
+
+	"github.com/gobs/pretty"
+)
+
+func TestNotificationPolicies(t *testing.T) {
+	t.Run("get policy tree succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 200, notificationPolicyJSON)
+		defer server.Close()
+		/*cfg := Config{
+			BasicAuth: url.UserPassword("admin", "admin"),
+		}
+		client, _ := New("http://localhost:3000", cfg)*/
+
+		np, err := client.NotificationPolicy()
+
+		if err != nil {
+			t.Error(err)
+		}
+		t.Log(pretty.PrettyFormat(np))
+		if np.Receiver != "grafana-default-email" {
+			t.Errorf("wrong receiver, got %#v", np.Receiver)
+		}
+		if len(np.Routes) != 1 {
+			t.Errorf("wrong number of routes returned, got %#v", np)
+		}
+	})
+}
+
+const notificationPolicyJSON = `
+{
+	"receiver": "grafana-default-email",
+	"group_by": [
+		"..."
+	],
+	"routes": [
+		{
+			"receiver": "grafana-default-email",
+			"object_matchers": [
+				[
+					"a",
+					"=",
+					"b"
+				],
+				[
+					"asdf",
+					"!=",
+					"jk"
+				]
+			]
+		}
+	],
+	"group_wait": "5s",
+	"group_interval": "1m",
+	"repeat_interval": "1h"
+}`

--- a/alerting_notification_policy_test.go
+++ b/alerting_notification_policy_test.go
@@ -10,10 +10,6 @@ func TestNotificationPolicies(t *testing.T) {
 	t.Run("get policy tree succeeds", func(t *testing.T) {
 		server, client := gapiTestTools(t, 200, notificationPolicyJSON)
 		defer server.Close()
-		/*cfg := Config{
-			BasicAuth: url.UserPassword("admin", "admin"),
-		}
-		client, _ := New("http://localhost:3000", cfg)*/
 
 		np, err := client.NotificationPolicy()
 
@@ -28,6 +24,52 @@ func TestNotificationPolicies(t *testing.T) {
 			t.Errorf("wrong number of routes returned, got %#v", np)
 		}
 	})
+
+	t.Run("set policy tree succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 202, `{"message":"created"}`)
+		defer server.Close()
+		np := createNotificationPolicy()
+
+		err := client.SetNotificationPolicy(&np)
+
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func createNotificationPolicy() NotificationPolicy {
+	return NotificationPolicy{
+		Receiver: "grafana-default-email",
+		GroupBy:  []string{"asdfasdf", "alertname"},
+		Routes: []SpecificPolicy{
+			{
+				Receiver: "grafana-default-email",
+				ObjectMatchers: Matchers{
+					{
+						Type:  MatchNotEqual,
+						Name:  "abc",
+						Value: "def",
+					},
+				},
+				Continue: true,
+			},
+			{
+				Receiver: "grafana-default-email",
+				ObjectMatchers: Matchers{
+					{
+						Type:  MatchRegexp,
+						Name:  "jkl",
+						Value: "something.*",
+					},
+				},
+				Continue: false,
+			},
+		},
+		GroupWait:      "10s",
+		GroupInterval:  "5m",
+		RepeatInterval: "4h",
+	}
 }
 
 const notificationPolicyJSON = `


### PR DESCRIPTION
Implements support for the notification policy resource in Unified Alerting. The Grafana Terraform provider will consume these new APIs in a future PR.