### PR TITLE
Alerting: Add method for fetching an entire rule group

### DIFF
--- a/alerting_alert_rule.go
+++ b/alerting_alert_rule.go
@@ -26,6 +26,14 @@ type AlertRule struct {
 	Provenance   string            `json:"provenance"`
 }
 
+// RuleGroup represents a group of rules in Grafana Alerting.
+type RuleGroup struct {
+	Title     string      `json:"title"`
+	FolderUID string      `json:"folderUid"`
+	Interval  int64       `json:"interval"`
+	Rules     []AlertRule `json:"rules"`
+}
+
 // AlertQuery represents a single query stage associated with an alert definition.
 type AlertQuery struct {
 	DatasourceUID     string            `json:"datasourceUid,omitempty"`
@@ -61,6 +69,14 @@ func (c *Client) AlertRule(uid string) (AlertRule, error) {
 	if err != nil {
 		return AlertRule{}, err
 	}
+	return result, err
+}
+
+// AlertRuleGroup fetches a group of alert rules, identified by its name and the UID of its folder.
+func (c *Client) AlertRuleGroup(folderUID string, name string) (RuleGroup, error) {
+	path := fmt.Sprintf("/api/v1/provisioning/folder/%s/rule-groups/%s", folderUID, name)
+	result := RuleGroup{}
+	err := c.request("GET", path, nil, nil, &result)
 	return result, err
 }
 

--- a/alerting_alert_rule_test.go
+++ b/alerting_alert_rule_test.go
@@ -22,6 +22,27 @@ func TestAlertRules(t *testing.T) {
 		}
 	})
 
+	t.Run("get alert rule group succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 200, getAlertRuleGroupJSON)
+		defer server.Close()
+
+		group, err := client.AlertRuleGroup("d8-gk06nz", "test")
+
+		if err != nil {
+			t.Error(err)
+		}
+		t.Log(pretty.PrettyFormat(group))
+		if group.Title != "test" {
+			t.Errorf("incorrect title - expected %s got %#v", "test", group)
+		}
+		if group.FolderUID != "d8-gk06nz" {
+			t.Errorf("incorrect folderUID - expected %s got %#v", "d8-gk06nz", group)
+		}
+		if len(group.Rules) != 1 {
+			t.Errorf("wrong number of rules, got %#v", group)
+		}
+	})
+
 	t.Run("get non-existent alert rule fails", func(t *testing.T) {
 		server, client := gapiTestTools(t, 404, "")
 		defer server.Close()
@@ -128,3 +149,92 @@ const getAlertRuleJSON = `
 	"for": 0
 }
 `
+
+const getAlertRuleGroupJSON = `
+{
+	"title": "test",
+	"folderUid": "d8-gk06nz",
+	"interval": 60,
+	"rules": [
+		{
+			"ID": 1,
+			"OrgID": 1,
+			"Title": "abc",
+			"Condition": "B",
+			"Data": [
+				{
+					"refId": "A",
+					"queryType": "",
+					"relativeTimeRange": {
+						"from": 600,
+						"to": 0
+					},
+					"datasourceUid": "PD8C576611E62080A",
+					"model": {
+						"hide": false,
+						"intervalMs": 1000,
+						"maxDataPoints": 43200,
+						"refId": "A"
+					}
+				},
+				{
+					"refId": "B",
+					"queryType": "",
+					"relativeTimeRange": {
+						"from": 0,
+						"to": 0
+					},
+					"datasourceUid": "-100",
+					"model": {
+						"conditions": [
+							{
+								"evaluator": {
+									"params": [
+										3
+									],
+									"type": "gt"
+								},
+								"operator": {
+									"type": "and"
+								},
+								"query": {
+									"params": [
+										"A"
+									]
+								},
+								"reducer": {
+									"params": [],
+									"type": "last"
+								},
+								"type": "query"
+							}
+						],
+						"datasource": {
+							"type": "__expr__",
+							"uid": "-100"
+						},
+						"hide": false,
+						"intervalMs": 1000,
+						"maxDataPoints": 43200,
+						"refId": "B",
+						"type": "classic_conditions"
+					}
+				}
+			],
+			"Updated": "2022-07-07T16:23:56-05:00",
+			"IntervalSeconds": 60,
+			"Version": 1,
+			"UID": "hsXgz0enz",
+			"NamespaceUID": "d8-gk06nz",
+			"DashboardUID": null,
+			"PanelID": null,
+			"RuleGroup": "test",
+			"RuleGroupIndex": 1,
+			"NoDataState": "NoData",
+			"ExecErrState": "Alerting",
+			"For": 300000000000,
+			"Annotations": {},
+			"Labels": {}
+		}
+	]
+}`

--- a/alerting_alert_rule_test.go
+++ b/alerting_alert_rule_test.go
@@ -18,7 +18,7 @@ func TestAlertRules(t *testing.T) {
 			t.Error(err)
 		}
 		if alertRule.UID != "123abcd" {
-			t.Errorf("incorrect UID - expected %s got %#v", "123abcd", alertRule.UID)
+			t.Errorf("incorrect UID - expected %s got %s", "123abcd", alertRule.UID)
 		}
 	})
 
@@ -33,13 +33,13 @@ func TestAlertRules(t *testing.T) {
 		}
 		t.Log(pretty.PrettyFormat(group))
 		if group.Title != "test" {
-			t.Errorf("incorrect title - expected %s got %#v", "test", group)
+			t.Errorf("incorrect title - expected %s got %s", "test", group.Title)
 		}
 		if group.FolderUID != "d8-gk06nz" {
-			t.Errorf("incorrect folderUID - expected %s got %#v", "d8-gk06nz", group)
+			t.Errorf("incorrect folderUID - expected %s got %s", "d8-gk06nz", group.FolderUID)
 		}
 		if len(group.Rules) != 1 {
-			t.Errorf("wrong number of rules, got %#v", group)
+			t.Errorf("wrong number of rules, got %d", len(group.Rules))
 		}
 	})
 


### PR DESCRIPTION
Adds a method wrapping a new Alerting endpoint which can fetch an entire rule group at once. This supplements the existing method to fetch just a single rule at a time.