### PR TITLE
Alerting: Add method for querying contact points by name

### DIFF
--- a/alerting_contact_point.go
+++ b/alerting_contact_point.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 )
 
 // ContactPoint represents a Grafana Alerting contact point.
@@ -20,6 +21,18 @@ type ContactPoint struct {
 func (c *Client) ContactPoints() ([]ContactPoint, error) {
 	ps := make([]ContactPoint, 0)
 	err := c.request("GET", "/api/v1/provisioning/contact-points", nil, nil, &ps)
+	if err != nil {
+		return nil, err
+	}
+	return ps, nil
+}
+
+// ContactPointsByName fetches contact points with the given name.
+func (c *Client) ContactPointsByName(name string) ([]ContactPoint, error) {
+	ps := make([]ContactPoint, 0)
+	params := url.Values{}
+	params.Add("name", name)
+	err := c.request("GET", "/api/v1/provisioning/contact-points", params, nil, &ps)
 	if err != nil {
 		return nil, err
 	}

--- a/alerting_contact_point_test.go
+++ b/alerting_contact_point_test.go
@@ -18,13 +18,13 @@ func TestContactPoints(t *testing.T) {
 		}
 		t.Log(pretty.PrettyFormat(ps))
 		if len(ps) != 2 {
-			t.Errorf("wrong number of contact points returned, got %#v", ps)
+			t.Errorf("wrong number of contact points returned, got %d", len(ps))
 		}
 		if ps[0].UID != "" {
-			t.Errorf("incorrect UID - expected %s on element %d, got %#v", "", 0, ps)
+			t.Errorf("incorrect UID - expected %s on element %d, got %s", "", 0, ps[0].UID)
 		}
 		if ps[1].UID != "rc5r0bjnz" {
-			t.Errorf("incorrect UID - expected %s on element %d, got %#v", "rc5r0bjnz", 0, ps)
+			t.Errorf("incorrect UID - expected %s on element %d, got %s", "rc5r0bjnz", 1, ps[1].UID)
 		}
 	})
 
@@ -39,10 +39,10 @@ func TestContactPoints(t *testing.T) {
 		}
 		t.Log(pretty.PrettyFormat(ps))
 		if len(ps) != 1 {
-			t.Errorf("wrong number of contact points returned, got %#v", ps)
+			t.Errorf("wrong number of contact points returned, got %d", len(ps))
 		}
 		if ps[0].UID != "rc5r0bjnz" {
-			t.Errorf("incorrect UID - expected %s on element %d, got %#v", "rc5r0bjnz", 0, ps)
+			t.Errorf("incorrect UID - expected %s on element %d, got %s", "rc5r0bjnz", 0, ps[0].UID)
 		}
 	})
 
@@ -57,7 +57,7 @@ func TestContactPoints(t *testing.T) {
 		}
 		t.Log(pretty.PrettyFormat(p))
 		if p.UID != "rc5r0bjnz" {
-			t.Errorf("incorrect UID - expected %s got %#v", "rc5r0bjnz", p)
+			t.Errorf("incorrect UID - expected %s got %s", "rc5r0bjnz", p.UID)
 		}
 	})
 

--- a/alerting_contact_point_test.go
+++ b/alerting_contact_point_test.go
@@ -28,6 +28,24 @@ func TestContactPoints(t *testing.T) {
 		}
 	})
 
+	t.Run("get contact points by name succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 200, getContactPointsQueryJSON)
+		defer server.Close()
+
+		ps, err := client.ContactPointsByName("slack-receiver-1")
+
+		if err != nil {
+			t.Error(err)
+		}
+		t.Log(pretty.PrettyFormat(ps))
+		if len(ps) != 1 {
+			t.Errorf("wrong number of contact points returned, got %#v", ps)
+		}
+		if ps[0].UID != "rc5r0bjnz" {
+			t.Errorf("incorrect UID - expected %s on element %d, got %#v", "rc5r0bjnz", 0, ps)
+		}
+	})
+
 	t.Run("get contact point succeeds", func(t *testing.T) {
 		server, client := gapiTestTools(t, 200, getContactPointsJSON)
 		defer server.Close()
@@ -119,6 +137,21 @@ const getContactPointsJSON = `
 			"addresses": "<example@email.com>"
 		}
 	},
+	{
+		"uid": "rc5r0bjnz",
+		"name": "slack-receiver-1",
+		"type": "slack",
+		"disableResolveMessage": false,
+		"settings": {
+			"recipient": "@foo",
+			"token": "[REDACTED]",
+			"url": "[REDACTED]"
+		}
+	}
+]`
+
+const getContactPointsQueryJSON = `
+[
 	{
 		"uid": "rc5r0bjnz",
 		"name": "slack-receiver-1",


### PR DESCRIPTION
This PR adds a method for getting contact points with a given name. This supplements the current method which gets all contact points.