### PR TITLE
Alerting: Add method for resetting notification policies

### DIFF
--- a/alerting_notification_policy.go
+++ b/alerting_notification_policy.go
@@ -118,3 +118,7 @@ func (c *Client) SetNotificationPolicy(np *NotificationPolicy) error {
 	}
 	return c.request("PUT", "/api/v1/provisioning/policies", nil, bytes.NewBuffer(req), nil)
 }
+
+func (c *Client) ResetNotificationPolicy() error {
+	return c.request("DELETE", "/api/v1/provisioning/policies", nil, nil, nil)
+}

--- a/alerting_notification_policy.go
+++ b/alerting_notification_policy.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Represents a notification routing tree in Grafana Alerting.
-type NotificationPolicy struct {
+type NotificationPolicyTree struct {
 	Receiver       string           `json:"receiver,omitempty"`
 	GroupBy        []string         `json:"group_by,omitempty"`
 	Routes         []SpecificPolicy `json:"routes,omitempty"`
@@ -104,14 +104,14 @@ func (m Matchers) MarshalJSON() ([]byte, error) {
 }
 
 // NotificationPolicy fetches the notification policy tree.
-func (c *Client) NotificationPolicyTree() (NotificationPolicy, error) {
-	np := NotificationPolicy{}
+func (c *Client) NotificationPolicyTree() (NotificationPolicyTree, error) {
+	np := NotificationPolicyTree{}
 	err := c.request("GET", "/api/v1/provisioning/policies", nil, nil, &np)
 	return np, err
 }
 
 // SetNotificationPolicy sets the notification policy tree.
-func (c *Client) SetNotificationPolicyTree(np *NotificationPolicy) error {
+func (c *Client) SetNotificationPolicyTree(np *NotificationPolicyTree) error {
 	req, err := json.Marshal(np)
 	if err != nil {
 		return err

--- a/alerting_notification_policy.go
+++ b/alerting_notification_policy.go
@@ -104,14 +104,14 @@ func (m Matchers) MarshalJSON() ([]byte, error) {
 }
 
 // NotificationPolicy fetches the notification policy tree.
-func (c *Client) NotificationPolicy() (NotificationPolicy, error) {
+func (c *Client) NotificationPolicyTree() (NotificationPolicy, error) {
 	np := NotificationPolicy{}
 	err := c.request("GET", "/api/v1/provisioning/policies", nil, nil, &np)
 	return np, err
 }
 
 // SetNotificationPolicy sets the notification policy tree.
-func (c *Client) SetNotificationPolicy(np *NotificationPolicy) error {
+func (c *Client) SetNotificationPolicyTree(np *NotificationPolicy) error {
 	req, err := json.Marshal(np)
 	if err != nil {
 		return err
@@ -119,6 +119,6 @@ func (c *Client) SetNotificationPolicy(np *NotificationPolicy) error {
 	return c.request("PUT", "/api/v1/provisioning/policies", nil, bytes.NewBuffer(req), nil)
 }
 
-func (c *Client) ResetNotificationPolicy() error {
+func (c *Client) ResetNotificationPolicyTree() error {
 	return c.request("DELETE", "/api/v1/provisioning/policies", nil, nil, nil)
 }

--- a/alerting_notification_policy_test.go
+++ b/alerting_notification_policy_test.go
@@ -36,6 +36,17 @@ func TestNotificationPolicies(t *testing.T) {
 			t.Error(err)
 		}
 	})
+
+	t.Run("reset policy tree succeeds", func(t *testing.T) {
+		server, client := gapiTestTools(t, 200, notificationPolicyJSON)
+		defer server.Close()
+
+		err := client.ResetNotificationPolicy()
+
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func createNotificationPolicy() NotificationPolicy {

--- a/alerting_notification_policy_test.go
+++ b/alerting_notification_policy_test.go
@@ -11,7 +11,7 @@ func TestNotificationPolicies(t *testing.T) {
 		server, client := gapiTestTools(t, 200, notificationPolicyJSON)
 		defer server.Close()
 
-		np, err := client.NotificationPolicy()
+		np, err := client.NotificationPolicyTree()
 
 		if err != nil {
 			t.Error(err)
@@ -30,7 +30,7 @@ func TestNotificationPolicies(t *testing.T) {
 		defer server.Close()
 		np := createNotificationPolicy()
 
-		err := client.SetNotificationPolicy(&np)
+		err := client.SetNotificationPolicyTree(&np)
 
 		if err != nil {
 			t.Error(err)
@@ -41,7 +41,7 @@ func TestNotificationPolicies(t *testing.T) {
 		server, client := gapiTestTools(t, 200, notificationPolicyJSON)
 		defer server.Close()
 
-		err := client.ResetNotificationPolicy()
+		err := client.ResetNotificationPolicyTree()
 
 		if err != nil {
 			t.Error(err)

--- a/alerting_notification_policy_test.go
+++ b/alerting_notification_policy_test.go
@@ -49,8 +49,8 @@ func TestNotificationPolicies(t *testing.T) {
 	})
 }
 
-func createNotificationPolicy() NotificationPolicy {
-	return NotificationPolicy{
+func createNotificationPolicy() NotificationPolicyTree {
+	return NotificationPolicyTree{
 		Receiver: "grafana-default-email",
 		GroupBy:  []string{"asdfasdf", "alertname"},
 		Routes: []SpecificPolicy{


### PR DESCRIPTION
Adds a method for "deleting" notification policies. Policies cannot actually be deleted - this resets the policy back to the default value.