### PR TITLE
Support UID for playlists

### DIFF
--- a/playlist.go
+++ b/playlist.go
@@ -23,12 +23,13 @@ type Playlist struct {
 	Items    []PlaylistItem `json:"items"`
 }
 
-func (p *Playlist) IDorUID() string {
-	if p.ID > 0 {
-		return fmt.Sprintf("%d", p.ID)
+// Grafana 9.0+ returns the ID and the UID but uses the UID in the API calls.
+// Grafana <9 only returns the ID.
+func (p *Playlist) QueryID() string {
+	if p.UID != "" {
+		return p.UID
 	}
-
-	return p.UID
+	return fmt.Sprintf("%d", p.ID)
 }
 
 // Playlist fetches and returns a Grafana playlist.
@@ -57,12 +58,12 @@ func (c *Client) NewPlaylist(playlist Playlist) (string, error) {
 		return "", err
 	}
 
-	return result.IDorUID(), nil
+	return result.QueryID(), nil
 }
 
 // UpdatePlaylist updates a Grafana playlist.
 func (c *Client) UpdatePlaylist(playlist Playlist) error {
-	path := fmt.Sprintf("/api/playlists/%s", playlist.IDorUID())
+	path := fmt.Sprintf("/api/playlists/%s", playlist.QueryID())
 	data, err := json.Marshal(playlist)
 	if err != nil {
 		return err

--- a/playlist.go
+++ b/playlist.go
@@ -23,6 +23,14 @@ type Playlist struct {
 	Items    []PlaylistItem `json:"items"`
 }
 
+func (p *Playlist) IDorUID() string {
+	if p.ID > 0 {
+		return fmt.Sprintf("%d", p.ID)
+	}
+
+	return p.UID
+}
+
 // Playlist fetches and returns a Grafana playlist.
 func (c *Client) Playlist(idOrUid string) (*Playlist, error) {
 	path := fmt.Sprintf("/api/playlists/%s", idOrUid)
@@ -36,27 +44,25 @@ func (c *Client) Playlist(idOrUid string) (*Playlist, error) {
 }
 
 // NewPlaylist creates a new Grafana playlist.
-func (c *Client) NewPlaylist(playlist Playlist) (int, error) {
+func (c *Client) NewPlaylist(playlist Playlist) (string, error) {
 	data, err := json.Marshal(playlist)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
-	result := struct {
-		ID int
-	}{}
+	var result Playlist
 
 	err = c.request("POST", "/api/playlists", nil, bytes.NewBuffer(data), &result)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
-	return result.ID, nil
+	return result.IDorUID(), nil
 }
 
 // UpdatePlaylist updates a Grafana playlist.
 func (c *Client) UpdatePlaylist(playlist Playlist) error {
-	path := fmt.Sprintf("/api/playlists/%d", playlist.ID)
+	path := fmt.Sprintf("/api/playlists/%s", playlist.IDorUID())
 	data, err := json.Marshal(playlist)
 	if err != nil {
 		return err
@@ -66,8 +72,8 @@ func (c *Client) UpdatePlaylist(playlist Playlist) error {
 }
 
 // DeletePlaylist deletes the Grafana playlist whose ID it's passed.
-func (c *Client) DeletePlaylist(id int) error {
-	path := fmt.Sprintf("/api/playlists/%d", id)
+func (c *Client) DeletePlaylist(idOrUID string) error {
+	path := fmt.Sprintf("/api/playlists/%s", idOrUID)
 
 	return c.request("DELETE", path, nil, nil, nil)
 }

--- a/playlist.go
+++ b/playlist.go
@@ -33,8 +33,8 @@ func (p *Playlist) QueryID() string {
 }
 
 // Playlist fetches and returns a Grafana playlist.
-func (c *Client) Playlist(idOrUid string) (*Playlist, error) {
-	path := fmt.Sprintf("/api/playlists/%s", idOrUid)
+func (c *Client) Playlist(idOrUID string) (*Playlist, error) {
+	path := fmt.Sprintf("/api/playlists/%s", idOrUID)
 	playlist := &Playlist{}
 	err := c.request("GET", path, nil, nil, playlist)
 	if err != nil {

--- a/playlist.go
+++ b/playlist.go
@@ -16,15 +16,16 @@ type PlaylistItem struct {
 
 // Playlist represents a Grafana playlist.
 type Playlist struct {
-	ID       int            `json:"id"`
+	ID       int            `json:"id,omitempty"`  // Grafana < 9.0
+	UID      string         `json:"uid,omitempty"` // Grafana >= 9.0
 	Name     string         `json:"name"`
 	Interval string         `json:"interval"`
 	Items    []PlaylistItem `json:"items"`
 }
 
 // Playlist fetches and returns a Grafana playlist.
-func (c *Client) Playlist(id int) (*Playlist, error) {
-	path := fmt.Sprintf("/api/playlists/%d", id)
+func (c *Client) Playlist(idOrUid string) (*Playlist, error) {
+	path := fmt.Sprintf("/api/playlists/%s", idOrUid)
 	playlist := &Playlist{}
 	err := c.request("GET", path, nil, nil, playlist)
 	if err != nil {

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -6,13 +6,13 @@ import (
 
 const (
 	createAndUpdatePlaylistResponse = `  {
-		"id": 1,
+		"uid": "1",
 		"name": "my playlist",
 		"interval": "5m"
 	}`
 
 	getPlaylistResponse = `{
-		"id" : 2,
+		"uid": "2",
 		"name": "my playlist",
 		"interval": "5m",
 		"orgId": "my org",
@@ -55,8 +55,8 @@ func TestPlaylistCreateAndUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if id != 1 {
-		t.Errorf("Invalid id - %d, Expected %d", id, 1)
+	if id != "1" {
+		t.Errorf("Invalid id - %s, Expected %s", id, "1")
 	}
 
 	// update
@@ -77,13 +77,13 @@ func TestGetPlaylist(t *testing.T) {
 	server, client := gapiTestTools(t, 200, getPlaylistResponse)
 	defer server.Close()
 
-	playlist, err := client.Playlist(1)
+	playlist, err := client.Playlist("2")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if playlist.ID != 2 {
-		t.Errorf("Invalid id - %d, Expected %d", playlist.ID, 1)
+	if playlist.UID != "2" {
+		t.Errorf("Invalid id - %s, Expected %s", playlist.UID, "2")
 	}
 
 	if len(playlist.Items) != 2 {
@@ -95,7 +95,7 @@ func TestDeletePlaylist(t *testing.T) {
 	server, client := gapiTestTools(t, 200, "")
 	defer server.Close()
 
-	err := client.DeletePlaylist(1)
+	err := client.DeletePlaylist("1")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is how Grafana 9.0 manages playlists now
This is done in a way that's retrocompatible with Grafana 8 though (id or UID accepted in functions)