### PR TITLE
Alerting: Fix timestamp serialization in mute timings

### DIFF
--- a/alerting_mute_timing.go
+++ b/alerting_mute_timing.go
@@ -24,8 +24,8 @@ type TimeInterval struct {
 
 // TimeRange represents a range of minutes within a 1440 minute day, exclusive of the End minute.
 type TimeRange struct {
-	StartMinute int
-	EndMinute   int
+	StartMinute string `json:"start_time"`
+	EndMinute   string `json:"end_time"`
 }
 
 // A WeekdayRange is an inclusive range of weekdays, e.g. "monday" or "tuesday:thursday".

--- a/alerting_mute_timing_test.go
+++ b/alerting_mute_timing_test.go
@@ -97,6 +97,12 @@ func createMuteTiming() MuteTiming {
 		Name: "timing two",
 		TimeIntervals: []TimeInterval{
 			{
+				Times: []TimeRange{
+					{
+						StartMinute: "13:13",
+						EndMinute:   "15:15",
+					},
+				},
 				Weekdays: []WeekdayRange{"monday", "wednesday"},
 				Months:   []MonthRange{"1:3", "4"},
 				Years:    []YearRange{"2022", "2023"},


### PR DESCRIPTION
The mute timing resource has overridden serialization code that behaves differently from Prometheus, where is where the existing code was adapted from. It was missed in tests as well, because the differently named JSON keys were simply ignored.

Fixed the types and json keys. Extended the tests to cover this.