### PR TITLE
Add methods for interacting with org preferences API (and a small bug fix)

### DIFF
--- a/org_preferences.go
+++ b/org_preferences.go
@@ -15,10 +15,6 @@ type UpdateOrgPreferencesResponse struct {
 func (c *Client) OrgPreferences() (Preferences, error) {
 	var prefs Preferences
 	err := c.request("GET", "/api/org/preferences", nil, nil, &prefs)
-	if err != nil {
-		return prefs, err
-	}
-
 	return prefs, err
 }
 

--- a/org_preferences.go
+++ b/org_preferences.go
@@ -1,0 +1,55 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// UpdateOrgPreferencesResponse represents the response to a request
+// updating Grafana org preferences.
+type UpdateOrgPreferencesResponse struct {
+	Message string `json:"message"`
+}
+
+// OrgPreferences fetches org preferences.
+func (c *Client) OrgPreferences() (Preferences, error) {
+	var prefs Preferences
+	err := c.request("GET", "/api/org/preferences", nil, nil, &prefs)
+	if err != nil {
+		return prefs, err
+	}
+
+	return prefs, err
+}
+
+// UpdateOrgPreferences updates only those org preferences specified in the passed Preferences, without impacting others.
+func (c *Client) UpdateOrgPreferences(p Preferences) (UpdateOrgPreferencesResponse, error) {
+	var resp UpdateOrgPreferencesResponse
+	data, err := json.Marshal(p)
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.request("PATCH", "/api/org/preferences", nil, bytes.NewBuffer(data), &resp)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+// UpdateAllOrgPreferences overrwrites all org preferences with the passed Preferences.
+func (c *Client) UpdateAllOrgPreferences(p Preferences) (UpdateOrgPreferencesResponse, error) {
+	var resp UpdateOrgPreferencesResponse
+	data, err := json.Marshal(p)
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.request("PUT", "/api/org/preferences", nil, bytes.NewBuffer(data), &resp)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}

--- a/org_preferences_test.go
+++ b/org_preferences_test.go
@@ -1,0 +1,59 @@
+package gapi
+
+import (
+	"testing"
+)
+
+const (
+	getOrgPreferencesJSON    = `{"theme": "foo","homeDashboardId": 0,"timezone": "","weekStart": "","navbar": {"savedItems": null},"queryHistory": {"homeTab": ""}}`
+	updateOrgPreferencesJSON = `{"message":"Preferences updated"}`
+)
+
+func TestOrgPreferences(t *testing.T) {
+	server, client := gapiTestTools(t, 200, getOrgPreferencesJSON)
+	defer server.Close()
+
+	resp, err := client.OrgPreferences()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "foo"
+	if resp.Theme != expected {
+		t.Errorf("Expected org preferences theme '%s'; got '%s'", expected, resp.Theme)
+	}
+}
+
+func TestUpdateOrgPreferences(t *testing.T) {
+	server, client := gapiTestTools(t, 200, updateOrgPreferencesJSON)
+	defer server.Close()
+
+	resp, err := client.UpdateOrgPreferences(Preferences{
+		Theme: "foo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Preferences updated"
+	if resp.Message != expected {
+		t.Errorf("Expected org preferences message '%s'; got '%s'", expected, resp.Message)
+	}
+}
+
+func TestUpdateAllOrgPreference(t *testing.T) {
+	server, client := gapiTestTools(t, 200, updateOrgPreferencesJSON)
+	defer server.Close()
+
+	resp, err := client.UpdateAllOrgPreferences(Preferences{
+		Theme: "foo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Preferences updated"
+	if resp.Message != expected {
+		t.Errorf("Expected org preferences message '%s'; got '%s'", expected, resp.Message)
+	}
+}

--- a/preferences.go
+++ b/preferences.go
@@ -1,0 +1,33 @@
+package gapi
+
+// NavLink represents a Grafana nav link.
+type NavLink struct {
+	ID     string `json:"id,omitempty"`
+	Text   string `json:"text,omitempty"`
+	URL    string `json:"url,omitempty"`
+	Target string `json:"target,omitempty"`
+}
+
+// NavbarPreference represents a Grafana navbar preference.
+type NavbarPreference struct {
+	SavedItems []NavLink `json:"savedItems"`
+}
+
+// QueryHistoryPreference represents a Grafana query history preference.
+type QueryHistoryPreference struct {
+	HomeTab string `json:"homeTab"`
+}
+
+// Preferences represents Grafana preferences.
+type Preferences struct {
+	Theme string `json:"theme"`
+	// TODO: research whether this should be homeDashboardId or homeDashboardID
+	// https://github.com/grafana/grafana/blob/8185b6fdf7b2f9bcef1f62dade4bb4087e23eba0/pkg/api/dtos/prefs.go#L7
+	HomeDashboardID  int64                  `json:"homeDashboardId"`
+	HomeDashboardUID string                 `json:"homeDashboardUID,omitempty"`
+	Timezone         string                 `json:"timezone,omitempty"`
+	WeekStart        string                 `json:"weekStart,omitempty"`
+	Locale           string                 `json:"locale,omitempty"`
+	Navbar           NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory     QueryHistoryPreference `json:"queryHistory,omitempty"`
+}

--- a/preferences.go
+++ b/preferences.go
@@ -20,9 +20,7 @@ type QueryHistoryPreference struct {
 
 // Preferences represents Grafana preferences.
 type Preferences struct {
-	Theme string `json:"theme"`
-	// TODO: research whether this should be homeDashboardId or homeDashboardID
-	// https://github.com/grafana/grafana/blob/8185b6fdf7b2f9bcef1f62dade4bb4087e23eba0/pkg/api/dtos/prefs.go#L7
+	Theme            string                 `json:"theme"`
 	HomeDashboardID  int64                  `json:"homeDashboardId"`
 	HomeDashboardUID string                 `json:"homeDashboardUID,omitempty"`
 	Timezone         string                 `json:"timezone,omitempty"`

--- a/team.go
+++ b/team.go
@@ -38,38 +38,6 @@ type TeamMember struct {
 	Permission int64  `json:"permission,omitempty"`
 }
 
-// NavLink represents a Grafana nav link.
-type NavLink struct {
-	ID     string `json:"id,omitempty"`
-	Text   string `json:"text,omitempty"`
-	URL    string `json:"url,omitempty"`
-	Target string `json:"target,omitempty"`
-}
-
-// NavbarPreference represents a Grafana navbar preference.
-type NavbarPreference struct {
-	SavedItems []NavLink `json:"savedItems"`
-}
-
-// QueryHistoryPreference represents a Grafana query history preference.
-type QueryHistoryPreference struct {
-	HomeTab string `json:"homeTab"`
-}
-
-// Preferences represents Grafana preferences.
-type Preferences struct {
-	Theme string `json:"theme"`
-	// TODO: research whether this should be homeDashboardId or homeDashboardID
-	// https://github.com/grafana/grafana/blob/8185b6fdf7b2f9bcef1f62dade4bb4087e23eba0/pkg/api/dtos/prefs.go#L7
-	HomeDashboardID  int64                  `json:"homeDashboardId"`
-	HomeDashboardUID string                 `json:"homeDashboardUID,omitempty"`
-	Timezone         string                 `json:"timezone,omitempty"`
-	WeekStart        string                 `json:"weekStart,omitempty"`
-	Locale           string                 `json:"locale,omitempty"`
-	Navbar           NavbarPreference       `json:"navbar,omitempty"`
-	QueryHistory     QueryHistoryPreference `json:"queryHistory,omitempty"`
-}
-
 // SearchTeam searches Grafana teams and returns the results.
 func (c *Client) SearchTeam(query string) (*SearchTeam, error) {
 	var result SearchTeam

--- a/team.go
+++ b/team.go
@@ -38,11 +38,36 @@ type TeamMember struct {
 	Permission int64  `json:"permission,omitempty"`
 }
 
+// NavLink represents a Grafana nav link.
+type NavLink struct {
+	ID     string `json:"id,omitempty"`
+	Text   string `json:"text,omitempty"`
+	URL    string `json:"url,omitempty"`
+	Target string `json:"target,omitempty"`
+}
+
+// NavbarPreference represents a Grafana navbar preference.
+type NavbarPreference struct {
+	SavedItems []NavLink `json:"savedItems"`
+}
+
+// QueryHistoryPreference represents a Grafana query history preference.
+type QueryHistoryPreference struct {
+	HomeTab string `json:"homeTab"`
+}
+
 // Preferences represents Grafana preferences.
 type Preferences struct {
-	Theme           string `json:"theme"`
-	HomeDashboardID int64  `json:"homeDashboardID"`
-	Timezone        string `json:"timezone"`
+	Theme string `json:"theme"`
+	// TODO: research whether this should be homeDashboardId or homeDashboardID
+	// https://github.com/grafana/grafana/blob/8185b6fdf7b2f9bcef1f62dade4bb4087e23eba0/pkg/api/dtos/prefs.go#L7
+	HomeDashboardID  int64                  `json:"homeDashboardId"`
+	HomeDashboardUID string                 `json:"homeDashboardUID,omitempty"`
+	Timezone         string                 `json:"timezone,omitempty"`
+	WeekStart        string                 `json:"weekStart,omitempty"`
+	Locale           string                 `json:"locale,omitempty"`
+	Navbar           NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory     QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 // SearchTeam searches Grafana teams and returns the results.


### PR DESCRIPTION
Hello! This PR seeks to...

1. Add methods for interacting with Grafana's [organization preferences API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs), itself largely in support of https://github.com/grafana/terraform-provider-grafana/issues/481 .
2. Fix what I believe to be a **small bug** in the `Preferences` type to correctly marshal/unmarshal a `homeDashboardId`JSON field. Previously, `grafana-api-golang-client` expected a `homeDashboardID` JSON field, but I don't believe that's correct based on the following; I believe the JSON field is `homeDashboardId`:
    * https://grafana.com/docs/grafana/latest/developers/http_api/team/#get-team-preferences
    * https://github.com/grafana/grafana/blob/main/pkg/api/dtos/prefs.go#L9

Thanks!