### PR TITLE
Alerting: Convenience translations for For field in alert rules

### DIFF
--- a/alerting_alert_rule.go
+++ b/alerting_alert_rule.go
@@ -22,7 +22,8 @@ type AlertRule struct {
 	Title        string            `json:"title"`
 	UID          string            `json:"uid,omitempty"`
 	Updated      time.Time         `json:"updated"`
-	ForDuration  time.Duration     `json:"for"`
+	For          string            `json:"for"`
+	ForDuration  time.Duration     `json:"-"`
 	Provenance   string            `json:"provenance"`
 }
 
@@ -82,6 +83,7 @@ func (c *Client) AlertRuleGroup(folderUID string, name string) (RuleGroup, error
 
 // SetAlertRuleGroup overwrites an existing rule group on the server.
 func (c *Client) SetAlertRuleGroup(group RuleGroup) error {
+	syncCalculatedRuleGroupFields(&group)
 	folderUID := group.FolderUID
 	name := group.Title
 	req, err := json.Marshal(group)
@@ -95,6 +97,7 @@ func (c *Client) SetAlertRuleGroup(group RuleGroup) error {
 
 // NewAlertRule creates a new alert rule and returns its UID.
 func (c *Client) NewAlertRule(ar *AlertRule) (string, error) {
+	syncCalculatedRuleFields(ar)
 	req, err := json.Marshal(ar)
 	if err != nil {
 		return "", err
@@ -109,6 +112,7 @@ func (c *Client) NewAlertRule(ar *AlertRule) (string, error) {
 
 // UpdateAlertRule replaces an alert rule, identified by the alert rule's UID.
 func (c *Client) UpdateAlertRule(ar *AlertRule) error {
+	syncCalculatedRuleFields(ar)
 	uri := fmt.Sprintf("/api/v1/provisioning/alert-rules/%s", ar.UID)
 	req, err := json.Marshal(ar)
 	if err != nil {
@@ -122,4 +126,51 @@ func (c *Client) UpdateAlertRule(ar *AlertRule) error {
 func (c *Client) DeleteAlertRule(uid string) error {
 	uri := fmt.Sprintf("/api/v1/provisioning/alert-rules/%s", uid)
 	return c.request("DELETE", uri, nil, nil, nil)
+}
+
+func syncCalculatedRuleGroupFields(group *RuleGroup) {
+	for i := range group.Rules {
+		syncCalculatedRuleFields(&group.Rules[i])
+	}
+}
+
+func syncCalculatedRuleFields(rule *AlertRule) {
+	// rule.For is the newer field. Older systems may not provide the value.
+	// If the user provided a For, prefer that over whatever we might calculate.
+	// Otherwise, translate the time.Duration-based field to the format that the rule API expects.
+	if rule.For == "" {
+		rule.For = timeDurationToRuleDuration(rule.ForDuration)
+	}
+}
+
+// timeDurationToRuleDuration converts a typical time.Duration to the string-based format that alert rules expect.
+func timeDurationToRuleDuration(d time.Duration) string {
+	ms := int64(d / time.Millisecond)
+	if ms == 0 {
+		return "0s"
+	}
+
+	r := ""
+	f := func(unit string, mult int64, exact bool) {
+		if exact && ms%mult != 0 {
+			return
+		}
+		if v := ms / mult; v > 0 {
+			r += fmt.Sprintf("%d%s", v, unit)
+			ms -= v * mult
+		}
+	}
+
+	// Only format years and weeks if the remainder is zero, as it is often
+	// easier to read 90d than 12w6d.
+	f("y", 1000*60*60*24*365, true)
+	f("w", 1000*60*60*24*7, true)
+
+	f("d", 1000*60*60*24, false)
+	f("h", 1000*60*60, false)
+	f("m", 1000*60, false)
+	f("s", 1000, false)
+	f("ms", 1, false)
+
+	return r
 }

--- a/alerting_alert_rule.go
+++ b/alerting_alert_rule.go
@@ -144,6 +144,7 @@ func syncCalculatedRuleFields(rule *AlertRule) {
 }
 
 // timeDurationToRuleDuration converts a typical time.Duration to the string-based format that alert rules expect.
+// This code is adapted from Prometheus: https://github.com/prometheus/common/blob/dfbc25bd00225c70aca0d94c3c4bb7744f28ace0/model/time.go#L236
 func timeDurationToRuleDuration(d time.Duration) string {
 	ms := int64(d / time.Millisecond)
 	if ms == 0 {

--- a/alerting_alert_rule_test.go
+++ b/alerting_alert_rule_test.go
@@ -27,17 +27,17 @@ func TestAlertRules(t *testing.T) {
 		server, client := gapiTestTools(t, 200, getAlertRuleGroupJSON)
 		defer server.Close()
 
-		group, err := client.AlertRuleGroup("d8-gk06nz", "test")
+		group, err := client.AlertRuleGroup("project_test", "eval_group_1")
 
 		if err != nil {
 			t.Error(err)
 		}
 		t.Log(pretty.PrettyFormat(group))
-		if group.Title != "test" {
-			t.Errorf("incorrect title - expected %s got %s", "test", group.Title)
+		if group.Title != "eval_group_1" {
+			t.Errorf("incorrect title - expected %s got %s", "eval_group_1", group.Title)
 		}
-		if group.FolderUID != "d8-gk06nz" {
-			t.Errorf("incorrect folderUID - expected %s got %s", "d8-gk06nz", group.FolderUID)
+		if group.FolderUID != "project_test" {
+			t.Errorf("incorrect folderUID - expected %s got %s", "project_test", group.FolderUID)
 		}
 		if len(group.Rules) != 1 {
 			t.Errorf("wrong number of rules, got %d", len(group.Rules))
@@ -187,89 +187,78 @@ const getAlertRuleJSON = `
 
 const getAlertRuleGroupJSON = `
 {
-	"title": "test",
-	"folderUid": "d8-gk06nz",
+	"title": "eval_group_1",
+	"folderUid": "project_test",
 	"interval": 60,
 	"rules": [
-		{
-			"ID": 1,
-			"OrgID": 1,
-			"Title": "abc",
-			"Condition": "B",
-			"Data": [
-				{
-					"refId": "A",
-					"queryType": "",
-					"relativeTimeRange": {
-						"from": 600,
-						"to": 0
+	  {
+		"id": 212,
+		"uid": "HW7RYci4z",
+		"orgID": 1,
+		"folderUID": "project_test",
+		"ruleGroup": "eval_group_1",
+		"title": "Always in alarm",
+		"condition": "A",
+		"data": [
+		  {
+			"refId": "A",
+			"queryType": "",
+			"relativeTimeRange": {
+			  "from": 0,
+			  "to": 0
+			},
+			"datasourceUid": "-100",
+			"model": {
+			  "datasourceUid": "-100",
+			  "intervalMs": 1000,
+			  "maxDataPoints": 43200,
+			  "model": {
+				"conditions": [
+				  {
+					"evaluator": {
+					  "params": [
+						0,
+						0
+					  ],
+					  "type": "gt"
 					},
-					"datasourceUid": "PD8C576611E62080A",
-					"model": {
-						"hide": false,
-						"intervalMs": 1000,
-						"maxDataPoints": 43200,
-						"refId": "A"
-					}
+					"operator": {
+					  "type": "and"
+					},
+					"query": {
+					  "params": []
+					},
+					"reducer": {
+					  "params": [],
+					  "type": "avg"
+					},
+					"type": "query"
+				  }
+				],
+				"datasource": {
+				  "type": "__expr__",
+				  "uid": "__expr__"
 				},
-				{
-					"refId": "B",
-					"queryType": "",
-					"relativeTimeRange": {
-						"from": 0,
-						"to": 0
-					},
-					"datasourceUid": "-100",
-					"model": {
-						"conditions": [
-							{
-								"evaluator": {
-									"params": [
-										3
-									],
-									"type": "gt"
-								},
-								"operator": {
-									"type": "and"
-								},
-								"query": {
-									"params": [
-										"A"
-									]
-								},
-								"reducer": {
-									"params": [],
-									"type": "last"
-								},
-								"type": "query"
-							}
-						],
-						"datasource": {
-							"type": "__expr__",
-							"uid": "-100"
-						},
-						"hide": false,
-						"intervalMs": 1000,
-						"maxDataPoints": 43200,
-						"refId": "B",
-						"type": "classic_conditions"
-					}
-				}
-			],
-			"Updated": "2022-07-07T16:23:56-05:00",
-			"IntervalSeconds": 60,
-			"Version": 1,
-			"UID": "hsXgz0enz",
-			"NamespaceUID": "d8-gk06nz",
-			"DashboardUID": null,
-			"PanelID": null,
-			"RuleGroup": "test",
-			"RuleGroupIndex": 1,
-			"NoDataState": "NoData",
-			"ExecErrState": "Alerting",
-			"For": "1m",
-			"Annotations": {},
-			"Labels": {}
-		}
+				"expression": "1 == 1",
+				"hide": false,
+				"intervalMs": 1000,
+				"maxDataPoints": 43200,
+				"refId": "A",
+				"type": "math"
+			  },
+			  "queryType": "",
+			  "refId": "A",
+			  "relativeTimeRange": {
+				"from": 0,
+				"to": 0
+			  }
+			}
+		  }
+		],
+		"updated": "2022-08-12T15:44:43-05:00",
+		"noDataState": "OK",
+		"execErrState": "OK",
+		"for": "2m"
+	  }
 	]
-}`
+  }`

--- a/alerting_alert_rule_test.go
+++ b/alerting_alert_rule_test.go
@@ -3,6 +3,7 @@ package gapi
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/gobs/pretty"
 )
@@ -138,7 +139,7 @@ func createAlertRule() AlertRule {
 		OrgID:        1,
 		RuleGroup:    "eval_group_1",
 		Title:        "Always in alarm",
-		ForDuration:  0,
+		ForDuration:  60 * time.Second,
 	}
 }
 
@@ -165,7 +166,7 @@ const writeAlertRuleJSON = `
 	"orgId": 1,
 	"ruleGroup": "eval_group_1",
 	"title": "Always in alarm",
-	"for": 0
+	"for": "1m"
 }
 `
 
@@ -180,7 +181,7 @@ const getAlertRuleJSON = `
 	"uid": "123abcd",
 	"ruleGroup": "eval_group_1",
 	"title": "Always in alarm",
-	"for": 0
+	"for": "1m"
 }
 `
 
@@ -266,7 +267,7 @@ const getAlertRuleGroupJSON = `
 			"RuleGroupIndex": 1,
 			"NoDataState": "NoData",
 			"ExecErrState": "Alerting",
-			"For": 300000000000,
+			"For": "1m",
 			"Annotations": {},
 			"Labels": {}
 		}


### PR DESCRIPTION
The `for` field in rules was broken for a while and was recently fixed in 9.1. This client also provided the value in the wrong format, using a raw serialized `time.Duration` rather than the string-based format that Prometheus expects.

This PR adds a new string field called `For` to the alert rule model, which takes the prom-style format.

We also add some convenience translations: whether the user wishes to provide a `time.Duration` or the prom-style duration, we now accept both and send the right thing regardless. The result is that this change is completely backwards-compatible, and improves the usability of the client by supporting whatever type the caller prefers.