### PR TITLE
Removed deprecated prop `AzureLogAnalyticsSameAs`

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -185,7 +185,6 @@ type JSONData struct {
 	Version       string `json:"version,omitempty"`
 
 	// Used by Azure Monitor
-	AzureLogAnalyticsSameAs      bool   `json:"azureLogAnalyticsSameAs"`
 	ClientID                     string `json:"clientId,omitempty"`
 	CloudName                    string `json:"cloudName,omitempty"`
 	LogAnalyticsClientID         string `json:"logAnalyticsClientId,omitempty"`

--- a/datasource.go
+++ b/datasource.go
@@ -187,9 +187,6 @@ type JSONData struct {
 	// Used by Azure Monitor
 	ClientID                     string `json:"clientId,omitempty"`
 	CloudName                    string `json:"cloudName,omitempty"`
-	LogAnalyticsClientID         string `json:"logAnalyticsClientId,omitempty"`
-	LogAnalyticsDefaultWorkspace string `json:"logAnalyticsDefaultWorkspace,omitempty"`
-	LogAnalyticsTenantID         string `json:"logAnalyticsTenantId,omitempty"`
 	SubscriptionID               string `json:"subscriptionId,omitempty"`
 	TenantID                     string `json:"tenantId,omitempty"`
 }

--- a/datasource.go
+++ b/datasource.go
@@ -185,10 +185,10 @@ type JSONData struct {
 	Version       string `json:"version,omitempty"`
 
 	// Used by Azure Monitor
-	ClientID                     string `json:"clientId,omitempty"`
-	CloudName                    string `json:"cloudName,omitempty"`
-	SubscriptionID               string `json:"subscriptionId,omitempty"`
-	TenantID                     string `json:"tenantId,omitempty"`
+	ClientID       string `json:"clientId,omitempty"`
+	CloudName      string `json:"cloudName,omitempty"`
+	SubscriptionID string `json:"subscriptionId,omitempty"`
+	TenantID       string `json:"tenantId,omitempty"`
 }
 
 // Required to avoid recursion during (un)marshal

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -212,12 +212,8 @@ func TestNewAzureDataSource(t *testing.T) {
 		Access:    "access",
 		IsDefault: true,
 		JSONData: JSONData{
-			AzureLogAnalyticsSameAs:      true,
 			ClientID:                     "lorem-ipsum",
 			CloudName:                    "azuremonitor",
-			LogAnalyticsClientID:         "lorem-ipsum",
-			LogAnalyticsDefaultWorkspace: "lorem-ipsum",
-			LogAnalyticsTenantID:         "lorem-ipsum",
 			SubscriptionID:               "lorem-ipsum",
 			TenantID:                     "lorem-ipsum",
 		},

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -212,10 +212,10 @@ func TestNewAzureDataSource(t *testing.T) {
 		Access:    "access",
 		IsDefault: true,
 		JSONData: JSONData{
-			ClientID:                     "lorem-ipsum",
-			CloudName:                    "azuremonitor",
-			SubscriptionID:               "lorem-ipsum",
-			TenantID:                     "lorem-ipsum",
+			ClientID:       "lorem-ipsum",
+			CloudName:      "azuremonitor",
+			SubscriptionID: "lorem-ipsum",
+			TenantID:       "lorem-ipsum",
 		},
 		SecureJSONData: SecureJSONData{
 			ClientSecret: "alksdjaslkdjkslajdkj.asdlkjaksdjlkajsdlkjsaldj==",


### PR DESCRIPTION
Following this escalation : https://github.com/grafana/support-escalations/issues/3560

Terraform is setting a [deprecated](https://github.com/grafana/grafana/pull/35121) bool to false when creating an Azure Monitor data source, this PR removes the deprecated prop.

**_Note to Reviewer_**
Happy for you to weigh in if you think that this fix is not right for the escalation above, 
I have very limited terraform context 😃 