### PR TITLE
Fix retry logic sending empty request bodies on subsequent retries

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,9 +71,9 @@ func (c *Client) request(method, requestPath string, query url.Values, body io.R
 		bodyContents []byte
 	)
 
-	// If we want to retry the request, we'll need to stash the request data in memory. Otherwise, we lose it since readers cannot be replayed.
+	// If we want to retry a request that sends data, we'll need to stash the request data in memory. Otherwise, we lose it since readers cannot be replayed.
 	var bodyBuffer bytes.Buffer
-	if c.config.NumRetries > 0 {
+	if c.config.NumRetries > 0 && body != nil {
 		body = io.TeeReader(body, &bodyBuffer)
 	}
 


### PR DESCRIPTION
`client.request()` performs retries if the server responds with a non-200 status code. It takes an `io.Reader` for the request body to send. Since a reader is a stream, it can only be consumed once, and it becomes fully exhausted after the first request in the retry loop. Therefore, the following retries will always be sent with an empty request body, rather than the intended one.

In order to retry a request at this layer, we must stash it in memory. If the `io.Reader` truly cannot be consumed twice, it's impossible to retry the request in the first place.

This PR makes an in-memory copy of the request body which is then sent in each retry attempt.

I manually checked every use case of `c.request` in the client - every single caller is sending a byte slice stored in memory to begin with. Therefore, this PR does not run the risk of bringing a massive request into memory, as we'd already be doing it anyway in the current implementation. We also only perform the copy if the request both has a body, and opted into retries.

An alternative approach would be to make `c.request()` take a byte slice straight up, since every caller is using it that way anyway. I can go down this route if you would prefer. I originally avoided it in order to touch a minimum amount of code.

Discovered here: https://github.com/grafana/terraform-provider-grafana/issues/630