### PR TITLE
Paginate user calls

### DIFF
--- a/user.go
+++ b/user.go
@@ -53,7 +53,7 @@ func (c *Client) Users() (users []UserSearch, err error) {
 	for len(newUsers) > 0 || page == 0 {
 		query := url.Values{}
 		query.Add("page", fmt.Sprintf("%d", page))
-		if err = c.request("GET", "/api/users", query, nil, &users); err != nil {
+		if err = c.request("GET", "/api/users", query, nil, &newUsers); err != nil {
 			return
 		}
 		users = append(users, newUsers...)

--- a/user.go
+++ b/user.go
@@ -46,7 +46,20 @@ type UserSearch struct {
 
 // Users fetches and returns Grafana users.
 func (c *Client) Users() (users []UserSearch, err error) {
-	err = c.request("GET", "/api/users", nil, nil, &users)
+	var (
+		page     = 0
+		newUsers []UserSearch
+	)
+	for len(newUsers) > 0 || page == 0 {
+		query := url.Values{}
+		query.Add("page", fmt.Sprintf("%d", page))
+		if err = c.request("GET", "/api/users", query, nil, &users); err != nil {
+			return
+		}
+		users = append(users, newUsers...)
+		page++
+	}
+
 	return
 }
 

--- a/user.go
+++ b/user.go
@@ -50,7 +50,7 @@ func (c *Client) Users() (users []UserSearch, err error) {
 		page     = 1
 		newUsers []UserSearch
 	)
-	for len(newUsers) > 0 || page == 0 {
+	for len(newUsers) > 0 || page == 1 {
 		query := url.Values{}
 		query.Add("page", fmt.Sprintf("%d", page))
 		if err = c.request("GET", "/api/users", query, nil, &newUsers); err != nil {

--- a/user.go
+++ b/user.go
@@ -47,7 +47,7 @@ type UserSearch struct {
 // Users fetches and returns Grafana users.
 func (c *Client) Users() (users []UserSearch, err error) {
 	var (
-		page     = 0
+		page     = 1
 		newUsers []UserSearch
 	)
 	for len(newUsers) > 0 || page == 0 {

--- a/user_test.go
+++ b/user_test.go
@@ -14,7 +14,10 @@ const (
 )
 
 func TestUsers(t *testing.T) {
-	client := gapiTestTools(t, 200, getUsersJSON)
+	client := gapiTestToolsFromCalls(t, []mockServerCall{
+		{200, getUsersJSON},
+		{200, "null"},
+	})
 
 	resp, err := client.Users()
 	if err != nil {


### PR DESCRIPTION
`Users` should get the full list of users, but it currently only returns a single page (1000 items by default). Needed for https://github.com/grafana/terraform-provider-grafana/pull/724