### PR TITLE
Another field for `builtinrole` for data source permissions

### DIFF
--- a/datasource_permissions.go
+++ b/datasource_permissions.go
@@ -25,6 +25,7 @@ type DatasourcePermission struct {
 
 	// Permission levels are
 	// 1 = Query
+	// 2 = Edit
 	Permission     DatasourcePermissionType `json:"permission"`
 	PermissionName string                   `json:"permissionName"`
 }
@@ -36,9 +37,10 @@ type DatasourcePermissionsResponse struct {
 }
 
 type DatasourcePermissionAddPayload struct {
-	UserID     int64                    `json:"userId"`
-	TeamID     int64                    `json:"teamId"`
-	Permission DatasourcePermissionType `json:"permission"`
+	UserID      int64                    `json:"userId"`
+	TeamID      int64                    `json:"teamId"`
+	BuiltInRole string                   `json:"builtinRole"`
+	Permission  DatasourcePermissionType `json:"permission"`
 }
 
 // EnableDatasourcePermissions enables the datasource permissions (this is a datasource setting)

--- a/datasource_permissions_test.go
+++ b/datasource_permissions_test.go
@@ -31,6 +31,14 @@ const (
 			"permissionName": "Query",
 			"created": "2017-06-20T02:00:00+02:00",
 			"updated": "2017-06-20T02:00:00+02:00"
+		},
+		{
+			"datasourceId": 1,
+			"permission": 2,
+			"permissionName": "Edit",
+			"builtInRole": "Viewer",
+			"created": "2017-06-20T02:00:00+02:00",
+			"updated": "2017-06-20T02:00:00+02:00"
 		}
 	]
 }`
@@ -92,6 +100,10 @@ func TestAddDatasourcePermissions(t *testing.T) {
 		{
 			UserID:     11,
 			Permission: 1,
+		},
+		{
+			BuiltInRole: "Viewer",
+			Permission:  2,
 		},
 	} {
 		err := client.AddDatasourcePermission(1, item)


### PR DESCRIPTION
In https://github.com/grafana/grafana-api-golang-client/pull/115 I forgot to add the `builtinRole` field to data source permission updates. This is required for https://github.com/grafana/terraform-provider-grafana/pull/692.