### PR TITLE
Datasource: add delete datasource by name method

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -132,3 +132,10 @@ func (c *Client) DeleteDataSource(id int64) error {
 
 	return c.request("DELETE", path, nil, nil, nil)
 }
+
+// DeleteDataSourceByName deletes the Grafana data source whose NAME it's passed.
+func (c *Client) DeleteDataSourceByName(name string) error {
+	path := fmt.Sprintf("/api/datasources/name/%s", name)
+
+	return c.request("DELETE", path, nil, nil, nil)
+}

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -317,3 +317,13 @@ func TestDataSourceIDByName(t *testing.T) {
 		t.Error("Not correctly parsing returned datasources.")
 	}
 }
+
+func TestDeleteDataSourceByName(t *testing.T) {
+	server, client := gapiTestTools(t, 200, "")
+	defer server.Close()
+
+	err := client.DeleteDataSourceByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
add delete datasource by name API.
[API-doc](https://grafana.com/docs/grafana/v9.0/developers/http_api/data_source/#delete-an-existing-data-source-by-name).

Signed-off-by: guykomari <guykomari@gmail.com>