### PR TITLE
Test Suite: Specify all expected server responses

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -21,8 +21,7 @@ const (
 )
 
 func TestCreateUser(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createUserJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createUserJSON)
 	user := User{
 		Email:    "admin@localhost",
 		Login:    "admin",
@@ -40,8 +39,7 @@ func TestCreateUser(t *testing.T) {
 }
 
 func TestDeleteUser(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deleteUserJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deleteUserJSON)
 
 	err := client.DeleteUser(int64(1))
 	if err != nil {
@@ -50,8 +48,7 @@ func TestDeleteUser(t *testing.T) {
 }
 
 func TestUpdateUserPassword(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateUserPasswordJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateUserPasswordJSON)
 
 	err := client.UpdateUserPassword(int64(1), "new-password")
 	if err != nil {
@@ -60,8 +57,7 @@ func TestUpdateUserPassword(t *testing.T) {
 }
 
 func TestUpdateUserPermissions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateUserPermissionsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateUserPermissionsJSON)
 
 	err := client.UpdateUserPermissions(int64(1), false)
 	if err != nil {
@@ -70,8 +66,7 @@ func TestUpdateUserPermissions(t *testing.T) {
 }
 
 func TestPauseAllAlerts(t *testing.T) {
-	server, client := gapiTestTools(t, 200, pauseAllAlertsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, pauseAllAlertsJSON)
 
 	res, err := client.PauseAllAlerts()
 	if err != nil {
@@ -86,8 +81,7 @@ func TestPauseAllAlerts(t *testing.T) {
 }
 
 func TestPauseAllAlerts_500(t *testing.T) {
-	server, client := gapiTestTools(t, 500, pauseAllAlertsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 500, pauseAllAlertsJSON)
 
 	_, err := client.PauseAllAlerts()
 	if !strings.Contains(err.Error(), "status: 500") {

--- a/alert_test.go
+++ b/alert_test.go
@@ -47,8 +47,7 @@ const (
 )
 
 func TestAlerts(t *testing.T) {
-	server, client := gapiTestTools(t, 200, alertsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, alertsJSON)
 
 	params := url.Values{}
 	params.Add("dashboardId", "123")
@@ -66,8 +65,7 @@ func TestAlerts(t *testing.T) {
 }
 
 func TestAlerts_500(t *testing.T) {
-	server, client := gapiTestTools(t, 500, alertsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 500, alertsJSON)
 
 	params := url.Values{}
 	params.Add("dashboardId", "123")
@@ -79,8 +77,7 @@ func TestAlerts_500(t *testing.T) {
 }
 
 func TestAlert(t *testing.T) {
-	server, client := gapiTestTools(t, 200, alertJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, alertJSON)
 
 	res, err := client.Alert(1)
 	if err != nil {
@@ -95,8 +92,7 @@ func TestAlert(t *testing.T) {
 }
 
 func TestAlert_500(t *testing.T) {
-	server, client := gapiTestTools(t, 500, alertJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 500, alertJSON)
 
 	_, err := client.Alert(1)
 	if !strings.Contains(err.Error(), "status: 500") {
@@ -105,8 +101,7 @@ func TestAlert_500(t *testing.T) {
 }
 
 func TestPauseAlert(t *testing.T) {
-	server, client := gapiTestTools(t, 200, pauseAlertJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, pauseAlertJSON)
 
 	res, err := client.PauseAlert(1)
 	if err != nil {
@@ -121,8 +116,7 @@ func TestPauseAlert(t *testing.T) {
 }
 
 func TestPauseAlert_500(t *testing.T) {
-	server, client := gapiTestTools(t, 500, pauseAlertJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 500, pauseAlertJSON)
 
 	_, err := client.PauseAlert(1)
 	if !strings.Contains(err.Error(), "status: 500") {

--- a/alerting_alert_rule_test.go
+++ b/alerting_alert_rule_test.go
@@ -10,8 +10,7 @@ import (
 
 func TestAlertRules(t *testing.T) {
 	t.Run("get alert rule succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, getAlertRuleJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, getAlertRuleJSON)
 
 		alertRule, err := client.AlertRule("123abcd")
 
@@ -24,8 +23,7 @@ func TestAlertRules(t *testing.T) {
 	})
 
 	t.Run("get alert rule group succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, getAlertRuleGroupJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, getAlertRuleGroupJSON)
 
 		group, err := client.AlertRuleGroup("project_test", "eval_group_1")
 
@@ -45,8 +43,7 @@ func TestAlertRules(t *testing.T) {
 	})
 
 	t.Run("get non-existent alert rule fails", func(t *testing.T) {
-		server, client := gapiTestTools(t, 404, "")
-		defer server.Close()
+		client := gapiTestTools(t, 404, "")
 
 		alertRule, err := client.AlertRule("does not exist")
 
@@ -57,8 +54,7 @@ func TestAlertRules(t *testing.T) {
 	})
 
 	t.Run("get non-existent rule group fails", func(t *testing.T) {
-		server, client := gapiTestTools(t, 404, "")
-		defer server.Close()
+		client := gapiTestTools(t, 404, "")
 
 		group, err := client.AlertRuleGroup("d8-gk06nz", "does not exist")
 
@@ -69,8 +65,7 @@ func TestAlertRules(t *testing.T) {
 	})
 
 	t.Run("create alert rule succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 201, writeAlertRuleJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 201, writeAlertRuleJSON)
 		alertRule := createAlertRule()
 
 		uid, err := client.NewAlertRule(&alertRule)
@@ -84,8 +79,7 @@ func TestAlertRules(t *testing.T) {
 	})
 
 	t.Run("set alert rule group succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, getAlertRuleGroupJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, getAlertRuleGroupJSON)
 		group := createAlertRuleGroup()
 
 		err := client.SetAlertRuleGroup(group)
@@ -96,8 +90,7 @@ func TestAlertRules(t *testing.T) {
 	})
 
 	t.Run("update alert rule succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, writeAlertRuleJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, writeAlertRuleJSON)
 		alertRule := createAlertRule()
 		alertRule.UID = "foobar"
 
@@ -109,8 +102,7 @@ func TestAlertRules(t *testing.T) {
 	})
 
 	t.Run("delete alert rule succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 204, "")
-		defer server.Close()
+		client := gapiTestTools(t, 204, "")
 
 		err := client.DeleteAlertRule("123abcd")
 

--- a/alerting_contact_point_test.go
+++ b/alerting_contact_point_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestContactPoints(t *testing.T) {
 	t.Run("get contact points succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, getContactPointsJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, getContactPointsJSON)
 
 		ps, err := client.ContactPoints()
 
@@ -29,8 +28,7 @@ func TestContactPoints(t *testing.T) {
 	})
 
 	t.Run("get contact points by name succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, getContactPointsQueryJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, getContactPointsQueryJSON)
 
 		ps, err := client.ContactPointsByName("slack-receiver-1")
 
@@ -47,8 +45,7 @@ func TestContactPoints(t *testing.T) {
 	})
 
 	t.Run("get contact point succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, getContactPointsJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, getContactPointsJSON)
 
 		p, err := client.ContactPoint("rc5r0bjnz")
 
@@ -62,8 +59,7 @@ func TestContactPoints(t *testing.T) {
 	})
 
 	t.Run("get non-existent contact point fails", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, getContactPointsJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, getContactPointsJSON)
 
 		p, err := client.ContactPoint("does not exist")
 
@@ -74,8 +70,7 @@ func TestContactPoints(t *testing.T) {
 	})
 
 	t.Run("create contact point succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 201, writeContactPointJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 201, writeContactPointJSON)
 		p := createContactPoint()
 
 		uid, err := client.NewContactPoint(&p)
@@ -89,8 +84,7 @@ func TestContactPoints(t *testing.T) {
 	})
 
 	t.Run("update contact point succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, writeContactPointJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, writeContactPointJSON)
 		p := createContactPoint()
 		p.UID = "on7otbj7k"
 
@@ -102,8 +96,7 @@ func TestContactPoints(t *testing.T) {
 	})
 
 	t.Run("delete contact point succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 204, "")
-		defer server.Close()
+		client := gapiTestTools(t, 204, "")
 
 		err := client.DeleteContactPoint("rc5r0bjnz")
 

--- a/alerting_message_template_test.go
+++ b/alerting_message_template_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestMessageTemplates(t *testing.T) {
 	t.Run("get message templates succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, getMessageTemplatesJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, getMessageTemplatesJSON)
 
 		ts, err := client.MessageTemplates()
 
@@ -29,8 +28,7 @@ func TestMessageTemplates(t *testing.T) {
 	})
 
 	t.Run("get message template succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, messageTemplateJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, messageTemplateJSON)
 
 		tmpl, err := client.MessageTemplate("template-one")
 
@@ -44,8 +42,7 @@ func TestMessageTemplates(t *testing.T) {
 	})
 
 	t.Run("get non-existent message template fails", func(t *testing.T) {
-		server, client := gapiTestTools(t, 404, ``)
-		defer server.Close()
+		client := gapiTestTools(t, 404, ``)
 
 		tmpl, err := client.MessageTemplate("does not exist")
 
@@ -56,8 +53,7 @@ func TestMessageTemplates(t *testing.T) {
 	})
 
 	t.Run("put message template succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 202, messageTemplateJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 202, messageTemplateJSON)
 
 		err := client.SetMessageTemplate("template-three", "{{define \"template-one\" }}\n  content three\n{{ end }}")
 
@@ -67,8 +63,7 @@ func TestMessageTemplates(t *testing.T) {
 	})
 
 	t.Run("delete message template succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 204, ``)
-		defer server.Close()
+		client := gapiTestTools(t, 204, ``)
 
 		err := client.DeleteMessageTemplate("template-three")
 

--- a/alerting_mute_timing_test.go
+++ b/alerting_mute_timing_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestMuteTimings(t *testing.T) {
 	t.Run("get mute timings succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, getMuteTimingsJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, getMuteTimingsJSON)
 
 		mts, err := client.MuteTimings()
 
@@ -29,8 +28,7 @@ func TestMuteTimings(t *testing.T) {
 	})
 
 	t.Run("get mute timing succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, muteTimingJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, muteTimingJSON)
 
 		mt, err := client.MuteTiming("timing one")
 
@@ -44,8 +42,7 @@ func TestMuteTimings(t *testing.T) {
 	})
 
 	t.Run("get non-existent mute timing fails", func(t *testing.T) {
-		server, client := gapiTestTools(t, 404, muteTimingJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 404, muteTimingJSON)
 
 		mt, err := client.MuteTiming("does not exist")
 
@@ -56,8 +53,7 @@ func TestMuteTimings(t *testing.T) {
 	})
 
 	t.Run("create mute timing succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 201, muteTimingJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 201, muteTimingJSON)
 		mt := createMuteTiming()
 
 		err := client.NewMuteTiming(&mt)
@@ -68,8 +64,7 @@ func TestMuteTimings(t *testing.T) {
 	})
 
 	t.Run("update mute timing succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, muteTimingJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, muteTimingJSON)
 		mt := createMuteTiming()
 		mt.TimeIntervals[0].Weekdays = []WeekdayRange{"tuesday", "thursday"}
 
@@ -81,8 +76,7 @@ func TestMuteTimings(t *testing.T) {
 	})
 
 	t.Run("delete mute timing succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 204, muteTimingJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 204, muteTimingJSON)
 
 		err := client.DeleteMuteTiming("timing two")
 

--- a/alerting_notification_policy_test.go
+++ b/alerting_notification_policy_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestNotificationPolicies(t *testing.T) {
 	t.Run("get policy tree succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, notificationPolicyJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, notificationPolicyJSON)
 
 		np, err := client.NotificationPolicyTree()
 
@@ -26,8 +25,7 @@ func TestNotificationPolicies(t *testing.T) {
 	})
 
 	t.Run("set policy tree succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 202, `{"message":"created"}`)
-		defer server.Close()
+		client := gapiTestTools(t, 202, `{"message":"created"}`)
 		np := createNotificationPolicy()
 
 		err := client.SetNotificationPolicyTree(&np)
@@ -38,8 +36,7 @@ func TestNotificationPolicies(t *testing.T) {
 	})
 
 	t.Run("reset policy tree succeeds", func(t *testing.T) {
-		server, client := gapiTestTools(t, 200, notificationPolicyJSON)
-		defer server.Close()
+		client := gapiTestTools(t, 200, notificationPolicyJSON)
 
 		err := client.ResetNotificationPolicyTree()
 

--- a/alertnotification_test.go
+++ b/alertnotification_test.go
@@ -76,8 +76,7 @@ const (
 )
 
 func TestAlertNotifications(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getAlertNotificationsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getAlertNotificationsJSON)
 
 	alertnotifications, err := client.AlertNotifications()
 	if err != nil {
@@ -95,8 +94,7 @@ func TestAlertNotifications(t *testing.T) {
 }
 
 func TestAlertNotification(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getAlertNotificationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getAlertNotificationJSON)
 
 	alertnotification := int64(1)
 	resp, err := client.AlertNotification(alertnotification)
@@ -112,8 +110,7 @@ func TestAlertNotification(t *testing.T) {
 }
 
 func TestNewAlertNotification(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdAlertNotificationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdAlertNotificationJSON)
 
 	an := &AlertNotification{
 		Name:                  "Team A",
@@ -139,8 +136,7 @@ func TestNewAlertNotification(t *testing.T) {
 }
 
 func TestUpdateAlertNotification(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updatedAlertNotificationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updatedAlertNotificationJSON)
 
 	an := &AlertNotification{
 		ID:                    1,
@@ -162,8 +158,7 @@ func TestUpdateAlertNotification(t *testing.T) {
 }
 
 func TestDeleteAlertNotification(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deletedAlertNotificationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deletedAlertNotificationJSON)
 
 	err := client.DeleteAlertNotification(1)
 	if err != nil {

--- a/annotation_test.go
+++ b/annotation_test.go
@@ -48,8 +48,7 @@ const (
 )
 
 func TestAnnotations(t *testing.T) {
-	server, client := gapiTestTools(t, 200, annotationsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, annotationsJSON)
 
 	params := url.Values{}
 	params.Add("from", "1506676478816")
@@ -69,8 +68,7 @@ func TestAnnotations(t *testing.T) {
 }
 
 func TestNewAnnotation(t *testing.T) {
-	server, client := gapiTestTools(t, 200, newAnnotationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, newAnnotationJSON)
 
 	a := Annotation{
 		DashboardID: 123,
@@ -94,8 +92,7 @@ func TestNewAnnotation(t *testing.T) {
 }
 
 func TestUpdateAnnotation(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateAnnotationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateAnnotationJSON)
 
 	a := Annotation{
 		Text: "new text description",
@@ -113,8 +110,7 @@ func TestUpdateAnnotation(t *testing.T) {
 }
 
 func TestPatchAnnotation(t *testing.T) {
-	server, client := gapiTestTools(t, 200, patchAnnotationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, patchAnnotationJSON)
 
 	a := Annotation{
 		Text: "new text description",
@@ -132,8 +128,7 @@ func TestPatchAnnotation(t *testing.T) {
 }
 
 func TestNewGraphiteAnnotation(t *testing.T) {
-	server, client := gapiTestTools(t, 200, newGraphiteAnnotationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, newGraphiteAnnotationJSON)
 
 	a := GraphiteAnnotation{
 		What: "what",
@@ -154,8 +149,7 @@ func TestNewGraphiteAnnotation(t *testing.T) {
 }
 
 func TestDeleteAnnotation(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deleteAnnotationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deleteAnnotationJSON)
 
 	res, err := client.DeleteAnnotation(1)
 	if err != nil {
@@ -170,8 +164,7 @@ func TestDeleteAnnotation(t *testing.T) {
 }
 
 func TestDeleteAnnotationByRegionID(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deleteAnnotationJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deleteAnnotationJSON)
 
 	res, err := client.DeleteAnnotationByRegionID(1)
 	if err != nil {

--- a/api_key_test.go
+++ b/api_key_test.go
@@ -26,8 +26,7 @@ const (
 )
 
 func TestCreateAPIKey(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createAPIKeyJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createAPIKeyJSON)
 
 	req := CreateAPIKeyRequest{
 		Name:          "key-name",
@@ -44,8 +43,7 @@ func TestCreateAPIKey(t *testing.T) {
 }
 
 func TestDeleteAPIKey(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deleteAPIKeyJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deleteAPIKeyJSON)
 
 	res, err := client.DeleteAPIKey(int64(1))
 	if err != nil {
@@ -56,8 +54,7 @@ func TestDeleteAPIKey(t *testing.T) {
 }
 
 func TestGetAPIKeys(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getAPIKeysJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getAPIKeysJSON)
 
 	res, err := client.GetAPIKeys(true)
 	if err != nil {

--- a/builtin_role_assignments_test.go
+++ b/builtin_role_assignments_test.go
@@ -41,10 +41,7 @@ const (
 )
 
 func TestNewBuiltInRoleAssignment(t *testing.T) {
-	server, client := gapiTestTools(t, 200, newBuiltInRoleAssignmentResponse)
-	t.Cleanup(func() {
-		server.Close()
-	})
+	client := gapiTestTools(t, 200, newBuiltInRoleAssignmentResponse)
 
 	br := BuiltInRoleAssignment{
 		Global:      false,
@@ -59,10 +56,7 @@ func TestNewBuiltInRoleAssignment(t *testing.T) {
 }
 
 func TestGetBuiltInRoleAssignments(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getBuiltInRoleAssignmentsResponse)
-	t.Cleanup(func() {
-		server.Close()
-	})
+	client := gapiTestTools(t, 200, getBuiltInRoleAssignmentsResponse)
 
 	resp, err := client.GetBuiltInRoleAssignments()
 
@@ -97,10 +91,7 @@ func TestGetBuiltInRoleAssignments(t *testing.T) {
 }
 
 func TestDeleteBuiltInRoleAssignment(t *testing.T) {
-	server, client := gapiTestTools(t, 200, removeBuiltInRoleAssignmentResponse)
-	t.Cleanup(func() {
-		server.Close()
-	})
+	client := gapiTestTools(t, 200, removeBuiltInRoleAssignmentResponse)
 
 	br := BuiltInRoleAssignment{
 		Global:      false,

--- a/client_test.go
+++ b/client_test.go
@@ -80,8 +80,7 @@ func TestNew_invalidURL(t *testing.T) {
 }
 
 func TestRequest_200(t *testing.T) {
-	server, client := gapiTestTools(t, 200, `{"foo":"bar"}`)
-	defer server.Close()
+	client := gapiTestTools(t, 200, `{"foo":"bar"}`)
 
 	err := client.request("GET", "/foo", url.Values{}, nil, nil)
 	if err != nil {
@@ -90,8 +89,7 @@ func TestRequest_200(t *testing.T) {
 }
 
 func TestRequest_201(t *testing.T) {
-	server, client := gapiTestTools(t, 201, `{"foo":"bar"}`)
-	defer server.Close()
+	client := gapiTestTools(t, 201, `{"foo":"bar"}`)
 
 	err := client.request("GET", "/foo", url.Values{}, nil, nil)
 	if err != nil {
@@ -100,8 +98,7 @@ func TestRequest_201(t *testing.T) {
 }
 
 func TestRequest_400(t *testing.T) {
-	server, client := gapiTestTools(t, 400, `{"foo":"bar"}`)
-	defer server.Close()
+	client := gapiTestTools(t, 400, `{"foo":"bar"}`)
 
 	expected := `status: 400, body: {"foo":"bar"}`
 	err := client.request("GET", "/foo", url.Values{}, nil, nil)
@@ -111,8 +108,7 @@ func TestRequest_400(t *testing.T) {
 }
 
 func TestRequest_500(t *testing.T) {
-	server, client := gapiTestTools(t, 500, `{"foo":"bar"}`)
-	defer server.Close()
+	client := gapiTestTools(t, 500, `{"foo":"bar"}`)
 
 	expected := `status: 500, body: {"foo":"bar"}`
 	err := client.request("GET", "/foo", url.Values{}, nil, nil)
@@ -122,13 +118,12 @@ func TestRequest_500(t *testing.T) {
 }
 
 func TestRequest_badURL(t *testing.T) {
-	server, client := gapiTestTools(t, 200, `{"foo":"bar"}`)
+	client := gapiTestTools(t, 200, `{"foo":"bar"}`)
 	baseURL, err := url.Parse("bad-url")
 	if err != nil {
 		t.Fatal(err)
 	}
 	client.baseURL = *baseURL
-	defer server.Close()
 
 	expected := `Get "bad-url/foo": unsupported protocol scheme ""`
 	err = client.request("GET", "/foo", url.Values{}, nil, nil)
@@ -138,8 +133,7 @@ func TestRequest_badURL(t *testing.T) {
 }
 
 func TestRequest_200Unmarshal(t *testing.T) {
-	server, client := gapiTestTools(t, 200, `{"foo":"bar"}`)
-	defer server.Close()
+	client := gapiTestTools(t, 200, `{"foo":"bar"}`)
 
 	result := struct {
 		Foo string `json:"foo"`
@@ -155,8 +149,7 @@ func TestRequest_200Unmarshal(t *testing.T) {
 }
 
 func TestRequest_200UnmarshalPut(t *testing.T) {
-	server, client := gapiTestTools(t, 200, `{"name":"mike"}`)
-	defer server.Close()
+	client := gapiTestTools(t, 200, `{"name":"mike"}`)
 
 	u := User{
 		Name: "mike",

--- a/cloud_plugin_test.go
+++ b/cloud_plugin_test.go
@@ -63,7 +63,7 @@ func TestInstallCloudPlugin(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404, 412} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 
 		installation, err = client.InstallCloudPlugin("some-stack", "some-plugin", "1.2.3")
 		if err == nil {
@@ -85,7 +85,7 @@ func TestUninstallCloudPlugin(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404, 412} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 
 		err = client.UninstallCloudPlugin("some-stack", "some-plugin")
 		if err == nil {
@@ -95,7 +95,7 @@ func TestUninstallCloudPlugin(t *testing.T) {
 }
 
 func TestIsCloudPluginInstalled(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getPluginJSON)
+	_, client := gapiTestTools(t, 200, getPluginJSON)
 
 	ok, err := client.IsCloudPluginInstalled("some-stack", "some-plugin")
 	if err != nil {
@@ -106,7 +106,7 @@ func TestIsCloudPluginInstalled(t *testing.T) {
 		t.Errorf("Expected plugin installation - Expected true, got false")
 	}
 
-	server.code = 404
+	_, client = gapiTestTools(t, 404, "error")
 	ok, err = client.IsCloudPluginInstalled("some-stack", "some-plugin")
 	if err != nil {
 		t.Error(err)
@@ -117,7 +117,7 @@ func TestIsCloudPluginInstalled(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 412} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 
 		_, err := client.IsCloudPluginInstalled("some-stack", "some-plugin")
 		if err == nil {
@@ -146,7 +146,7 @@ func TestGetCloudPluginInstallation(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404, 412} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 
 		installation, err = client.GetCloudPluginInstallation("some-stack", "some-plugin")
 		if err == nil {
@@ -178,7 +178,7 @@ func TestPlugin(t *testing.T) {
 	}
 
 	for _, code := range []int{404} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 
 		_, err = client.PluginBySlug("some-plugin")
 		if err == nil {
@@ -207,7 +207,7 @@ func TestPluginByID(t *testing.T) {
 	}
 
 	for _, code := range []int{404} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 
 		_, err = client.PluginByID(123)
 		if err == nil {

--- a/cloud_plugin_test.go
+++ b/cloud_plugin_test.go
@@ -44,8 +44,7 @@ const (
 )
 
 func TestInstallCloudPlugin(t *testing.T) {
-	server, client := gapiTestTools(t, 200, installPluginJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, installPluginJSON)
 
 	installation, err := client.InstallCloudPlugin("some-stack", "some-plugin", "1.2.3")
 	if err != nil {
@@ -63,7 +62,7 @@ func TestInstallCloudPlugin(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404, 412} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 
 		installation, err = client.InstallCloudPlugin("some-stack", "some-plugin", "1.2.3")
 		if err == nil {
@@ -76,8 +75,7 @@ func TestInstallCloudPlugin(t *testing.T) {
 }
 
 func TestUninstallCloudPlugin(t *testing.T) {
-	server, client := gapiTestTools(t, 200, uninstallPluginJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, uninstallPluginJSON)
 
 	err := client.UninstallCloudPlugin("some-stack", "some-plugin")
 	if err != nil {
@@ -85,7 +83,7 @@ func TestUninstallCloudPlugin(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404, 412} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 
 		err = client.UninstallCloudPlugin("some-stack", "some-plugin")
 		if err == nil {
@@ -95,7 +93,7 @@ func TestUninstallCloudPlugin(t *testing.T) {
 }
 
 func TestIsCloudPluginInstalled(t *testing.T) {
-	_, client := gapiTestTools(t, 200, getPluginJSON)
+	client := gapiTestTools(t, 200, getPluginJSON)
 
 	ok, err := client.IsCloudPluginInstalled("some-stack", "some-plugin")
 	if err != nil {
@@ -106,7 +104,7 @@ func TestIsCloudPluginInstalled(t *testing.T) {
 		t.Errorf("Expected plugin installation - Expected true, got false")
 	}
 
-	_, client = gapiTestTools(t, 404, "error")
+	client = gapiTestTools(t, 404, "error")
 	ok, err = client.IsCloudPluginInstalled("some-stack", "some-plugin")
 	if err != nil {
 		t.Error(err)
@@ -117,7 +115,7 @@ func TestIsCloudPluginInstalled(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 412} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 
 		_, err := client.IsCloudPluginInstalled("some-stack", "some-plugin")
 		if err == nil {
@@ -127,8 +125,7 @@ func TestIsCloudPluginInstalled(t *testing.T) {
 }
 
 func TestGetCloudPluginInstallation(t *testing.T) {
-	server, client := gapiTestTools(t, 200, installPluginJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, installPluginJSON)
 
 	installation, err := client.GetCloudPluginInstallation("some-stack", "some-plugin")
 	if err != nil {
@@ -146,7 +143,7 @@ func TestGetCloudPluginInstallation(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404, 412} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 
 		installation, err = client.GetCloudPluginInstallation("some-stack", "some-plugin")
 		if err == nil {
@@ -159,8 +156,7 @@ func TestGetCloudPluginInstallation(t *testing.T) {
 }
 
 func TestPlugin(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getPluginJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getPluginJSON)
 
 	plugin, err := client.PluginBySlug("some-plugin")
 	if err != nil {
@@ -178,7 +174,7 @@ func TestPlugin(t *testing.T) {
 	}
 
 	for _, code := range []int{404} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 
 		_, err = client.PluginBySlug("some-plugin")
 		if err == nil {
@@ -188,8 +184,7 @@ func TestPlugin(t *testing.T) {
 }
 
 func TestPluginByID(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getPluginJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getPluginJSON)
 
 	plugin, err := client.PluginBySlug("some-plugin")
 	if err != nil {
@@ -207,7 +202,7 @@ func TestPluginByID(t *testing.T) {
 	}
 
 	for _, code := range []int{404} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 
 		_, err = client.PluginByID(123)
 		if err == nil {

--- a/cloud_regions_test.go
+++ b/cloud_regions_test.go
@@ -91,8 +91,7 @@ var (
 )
 
 func TestCloudRegions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, cloudRegionsResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, cloudRegionsResponse)
 
 	regions, err := client.GetCloudRegions()
 
@@ -111,8 +110,7 @@ func TestCloudRegions(t *testing.T) {
 }
 
 func TestCloudRegionBySlug(t *testing.T) {
-	server, client := gapiTestTools(t, 200, cloudRegionResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, cloudRegionResponse)
 
 	resp, err := client.GetCloudRegionBySlug("us")
 	if err != nil {

--- a/cloud_stack_test.go
+++ b/cloud_stack_test.go
@@ -92,8 +92,7 @@ const (
 )
 
 func TestStacks(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getStacksJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getStacksJSON)
 
 	stacks, err := client.Stacks()
 
@@ -132,8 +131,7 @@ func TestStacks(t *testing.T) {
 }
 
 func TestCreateStack(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createStackJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createStackJSON)
 
 	stack := &CreateStackInput{
 		Name:   "mystack",
@@ -160,8 +158,7 @@ func TestCreateStack(t *testing.T) {
 }
 
 func TestStackBySlug(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getStackJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getStackJSON)
 
 	expectedStackSlug := "mystack"
 	resp, err := client.StackBySlug(expectedStackSlug)
@@ -177,8 +174,7 @@ func TestStackBySlug(t *testing.T) {
 }
 
 func TestStackByID(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getStackJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getStackJSON)
 
 	expectedStackID := int64(1)
 	resp, err := client.StackByID(expectedStackID)
@@ -195,8 +191,7 @@ func TestStackByID(t *testing.T) {
 }
 
 func TestUpdateStack(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getStacksJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getStacksJSON)
 
 	stack := &UpdateStackInput{
 		Name:        "mystack2",
@@ -211,8 +206,7 @@ func TestUpdateStack(t *testing.T) {
 }
 
 func TestDeleteStack(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getStacksJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getStacksJSON)
 
 	err := client.DeleteStack("mystack")
 

--- a/dashboard_permissions_test.go
+++ b/dashboard_permissions_test.go
@@ -57,8 +57,7 @@ const (
 )
 
 func TestDashboardPermissions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getDashboardPermissionsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getDashboardPermissionsJSON)
 
 	resp, err := client.DashboardPermissions(1)
 	if err != nil {
@@ -110,8 +109,7 @@ func TestDashboardPermissions(t *testing.T) {
 }
 
 func TestUpdateDashboardPermissions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateDashboardPermissionsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateDashboardPermissionsJSON)
 
 	items := &PermissionItems{
 		Items: []*PermissionItem{

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -69,7 +69,7 @@ func TestDashboardCreateAndUpdate(t *testing.T) {
 	}
 
 	for _, code := range []int{400, 401, 403, 412} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 		_, err = client.NewDashboard(dashboard)
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -90,6 +90,9 @@ func TestDashboardGet(t *testing.T) {
 		t.Errorf("Invalid uid - %s, Expected %s", uid, "cIBgcSjkk")
 	}
 
+	server, client = gapiTestTools(t, 200, getDashboardResponse)
+	defer server.Close()
+
 	resp, err = client.DashboardByUID("cIBgcSjkk")
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +103,7 @@ func TestDashboardGet(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 		_, err = client.Dashboard("test")
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -114,21 +117,23 @@ func TestDashboardGet(t *testing.T) {
 }
 
 func TestDashboardDelete(t *testing.T) {
-	server, client := gapiTestTools(t, 200, "")
-	defer server.Close()
 
+	server, client := gapiTestTools(t, 200, "")
 	err := client.DeleteDashboard("test")
 	if err != nil {
 		t.Error(err)
 	}
+	server.Close()
 
+	server, client = gapiTestTools(t, 200, "")
 	err = client.DeleteDashboardByUID("cIBgcSjkk")
 	if err != nil {
 		t.Fatal(err)
 	}
+	server.Close()
 
 	for _, code := range []int{401, 403, 404, 412} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 
 		err = client.DeleteDashboard("test")
 		if err == nil {

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -45,8 +45,7 @@ const (
 )
 
 func TestDashboardCreateAndUpdate(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdAndUpdateDashboardResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdAndUpdateDashboardResponse)
 
 	dashboard := Dashboard{
 		Model: map[string]interface{}{
@@ -69,7 +68,7 @@ func TestDashboardCreateAndUpdate(t *testing.T) {
 	}
 
 	for _, code := range []int{400, 401, 403, 412} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 		_, err = client.NewDashboard(dashboard)
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -78,8 +77,7 @@ func TestDashboardCreateAndUpdate(t *testing.T) {
 }
 
 func TestDashboardGet(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getDashboardResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getDashboardResponse)
 
 	resp, err := client.Dashboard("test")
 	if err != nil {
@@ -90,8 +88,7 @@ func TestDashboardGet(t *testing.T) {
 		t.Errorf("Invalid uid - %s, Expected %s", uid, "cIBgcSjkk")
 	}
 
-	server, client = gapiTestTools(t, 200, getDashboardResponse)
-	defer server.Close()
+	client = gapiTestTools(t, 200, getDashboardResponse)
 
 	resp, err = client.DashboardByUID("cIBgcSjkk")
 	if err != nil {
@@ -103,7 +100,7 @@ func TestDashboardGet(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 		_, err = client.Dashboard("test")
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -117,22 +114,20 @@ func TestDashboardGet(t *testing.T) {
 }
 
 func TestDashboardDelete(t *testing.T) {
-	server, client := gapiTestTools(t, 200, "")
+	client := gapiTestTools(t, 200, "")
 	err := client.DeleteDashboard("test")
 	if err != nil {
 		t.Error(err)
 	}
-	server.Close()
 
-	server, client = gapiTestTools(t, 200, "")
+	client = gapiTestTools(t, 200, "")
 	err = client.DeleteDashboardByUID("cIBgcSjkk")
 	if err != nil {
 		t.Fatal(err)
 	}
-	server.Close()
 
 	for _, code := range []int{401, 403, 404, 412} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 
 		err = client.DeleteDashboard("test")
 		if err == nil {
@@ -147,8 +142,7 @@ func TestDashboardDelete(t *testing.T) {
 }
 
 func TestDashboards(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getDashboardsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getDashboardsJSON)
 
 	dashboards, err := client.Dashboards()
 	if err != nil {

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -117,7 +117,6 @@ func TestDashboardGet(t *testing.T) {
 }
 
 func TestDashboardDelete(t *testing.T) {
-
 	server, client := gapiTestTools(t, 200, "")
 	err := client.DeleteDashboard("test")
 	if err != nil {

--- a/datasource_permissions_test.go
+++ b/datasource_permissions_test.go
@@ -89,7 +89,6 @@ func TestDatasourcePermissions(t *testing.T) {
 }
 
 func TestAddDatasourcePermissions(t *testing.T) {
-
 	for _, item := range []*DatasourcePermissionAddPayload{
 		{
 			TeamID:     1,

--- a/datasource_permissions_test.go
+++ b/datasource_permissions_test.go
@@ -48,8 +48,7 @@ const (
 )
 
 func TestDatasourcePermissions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getDatasourcePermissionsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getDatasourcePermissionsJSON)
 
 	resp, err := client.DatasourcePermissions(1)
 	if err != nil {
@@ -103,11 +102,10 @@ func TestAddDatasourcePermissions(t *testing.T) {
 			Permission:  2,
 		},
 	} {
-		server, client := gapiTestTools(t, 200, addDatasourcePermissionsJSON)
+		client := gapiTestTools(t, 200, addDatasourcePermissionsJSON)
 		err := client.AddDatasourcePermission(1, item)
 		if err != nil {
 			t.Error(err)
 		}
-		server.Close()
 	}
 }

--- a/datasource_permissions_test.go
+++ b/datasource_permissions_test.go
@@ -89,8 +89,6 @@ func TestDatasourcePermissions(t *testing.T) {
 }
 
 func TestAddDatasourcePermissions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, addDatasourcePermissionsJSON)
-	defer server.Close()
 
 	for _, item := range []*DatasourcePermissionAddPayload{
 		{
@@ -106,9 +104,11 @@ func TestAddDatasourcePermissions(t *testing.T) {
 			Permission:  2,
 		},
 	} {
+		server, client := gapiTestTools(t, 200, addDatasourcePermissionsJSON)
 		err := client.AddDatasourcePermission(1, item)
 		if err != nil {
 			t.Error(err)
 		}
+		server.Close()
 	}
 }

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -13,8 +13,7 @@ const (
 )
 
 func TestNewDataSource(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdDataSourceJSON)
 
 	jd, err := JSONData{
 		AssumeRoleArn:           "arn:aws:iam::123:role/some-role",
@@ -57,8 +56,7 @@ func TestNewDataSource(t *testing.T) {
 }
 
 func TestNewPrometheusDataSource(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdDataSourceJSON)
 
 	jd, err := JSONData{
 		HTTPMethod:   "POST",
@@ -91,8 +89,7 @@ func TestNewPrometheusDataSource(t *testing.T) {
 }
 
 func TestNewPrometheusSigV4DataSource(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdDataSourceJSON)
 
 	jd, err := JSONData{
 		HTTPMethod:    "POST",
@@ -134,8 +131,7 @@ func TestNewPrometheusSigV4DataSource(t *testing.T) {
 }
 
 func TestNewElasticsearchDataSource(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdDataSourceJSON)
 
 	jd, err := JSONData{
 		EsVersion:                  "7.0.0",
@@ -170,8 +166,7 @@ func TestNewElasticsearchDataSource(t *testing.T) {
 }
 
 func TestNewInfluxDBDataSource(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdDataSourceJSON)
 
 	jd, err := JSONData{
 		DefaultBucket: "telegraf",
@@ -211,8 +206,7 @@ func TestNewInfluxDBDataSource(t *testing.T) {
 }
 
 func TestNewOpenTSDBDataSource(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdDataSourceJSON)
 
 	jd, err := JSONData{
 		TsdbResolution: 1,
@@ -244,8 +238,7 @@ func TestNewOpenTSDBDataSource(t *testing.T) {
 }
 
 func TestNewAzureDataSource(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdDataSourceJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdDataSourceJSON)
 
 	jd, err := JSONData{
 		ClientID:       "lorem-ipsum",
@@ -286,8 +279,7 @@ func TestNewAzureDataSource(t *testing.T) {
 }
 
 func TestDataSources(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getDataSourcesJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getDataSourcesJSON)
 
 	datasources, err := client.DataSources()
 	if err != nil {
@@ -305,8 +297,7 @@ func TestDataSources(t *testing.T) {
 }
 
 func TestDataSourceIDByName(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getDataSourceJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getDataSourceJSON)
 
 	datasourceID, err := client.DataSourceIDByName("foo")
 	if err != nil {
@@ -319,8 +310,7 @@ func TestDataSourceIDByName(t *testing.T) {
 }
 
 func TestDeleteDataSourceByName(t *testing.T) {
-	server, client := gapiTestTools(t, 200, "")
-	defer server.Close()
+	client := gapiTestTools(t, 200, "")
 
 	err := client.DeleteDataSourceByName("foo")
 	if err != nil {

--- a/folder_dashboard_search_test.go
+++ b/folder_dashboard_search_test.go
@@ -48,8 +48,7 @@ const (
 )
 
 func TestFolderDashboardSearch(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getFolderDashboardSearchResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getFolderDashboardSearchResponse)
 	resp, err := client.FolderDashboardSearch(url.Values{})
 	if err != nil {
 		t.Fatal(err)

--- a/folder_permissions_test.go
+++ b/folder_permissions_test.go
@@ -57,8 +57,7 @@ const (
 )
 
 func TestFolderPermissions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getFolderPermissionsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getFolderPermissionsJSON)
 
 	fid := "nErXDvCkzz"
 	resp, err := client.FolderPermissions(fid)
@@ -105,8 +104,7 @@ func TestFolderPermissions(t *testing.T) {
 }
 
 func TestUpdateFolderPermissions(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateFolderPermissionsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateFolderPermissionsJSON)
 
 	items := &PermissionItems{
 		Items: []*PermissionItem{

--- a/folder_test.go
+++ b/folder_test.go
@@ -85,8 +85,7 @@ const (
 )
 
 func TestFolders(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getFoldersJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getFoldersJSON)
 
 	folders, err := client.Folders()
 	if err != nil {
@@ -104,8 +103,7 @@ func TestFolders(t *testing.T) {
 }
 
 func TestFolder(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getFolderJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getFolderJSON)
 
 	folder := int64(1)
 	resp, err := client.Folder(folder)
@@ -121,8 +119,7 @@ func TestFolder(t *testing.T) {
 }
 
 func TestFolderByUid(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getFolderJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getFolderJSON)
 
 	folder := "nErXDvCkzz"
 	resp, err := client.FolderByUID(folder)
@@ -138,8 +135,7 @@ func TestFolderByUid(t *testing.T) {
 }
 
 func TestNewFolder(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdFolderJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdFolderJSON)
 
 	resp, err := client.NewFolder("test-folder")
 	if err != nil {
@@ -154,8 +150,7 @@ func TestNewFolder(t *testing.T) {
 }
 
 func TestUpdateFolder(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updatedFolderJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updatedFolderJSON)
 
 	err := client.UpdateFolder("nErXDvCkzz", "test-folder")
 	if err != nil {
@@ -164,8 +159,7 @@ func TestUpdateFolder(t *testing.T) {
 }
 
 func TestDeleteFolder(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deletedFolderJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deletedFolderJSON)
 
 	err := client.DeleteFolder("nErXDvCkzz")
 	if err != nil {

--- a/library_panel_test.go
+++ b/library_panel_test.go
@@ -155,8 +155,7 @@ const (
 )
 
 func TestLibraryPanelCreate(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getLibraryPanelUIDResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getLibraryPanelUIDResponse)
 
 	panel := LibraryPanel{
 		Folder: 0,
@@ -176,7 +175,7 @@ func TestLibraryPanelCreate(t *testing.T) {
 	}
 
 	for _, code := range []int{400, 401, 403} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 		_, err = client.NewLibraryPanel(panel)
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -185,8 +184,7 @@ func TestLibraryPanelCreate(t *testing.T) {
 }
 
 func TestLibraryPanelGetByName(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getLibraryPanelNameResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getLibraryPanelNameResponse)
 
 	resp, err := client.LibraryPanelByName("API docs Example")
 	if err != nil {
@@ -197,7 +195,7 @@ func TestLibraryPanelGetByName(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 		_, err = client.LibraryPanelByName("test")
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -206,8 +204,7 @@ func TestLibraryPanelGetByName(t *testing.T) {
 }
 
 func TestLibraryPanelGetByUID(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getLibraryPanelUIDResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getLibraryPanelUIDResponse)
 
 	resp, err := client.LibraryPanelByUID("V--OrYHnz")
 	if err != nil {
@@ -218,7 +215,7 @@ func TestLibraryPanelGetByUID(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 		_, err = client.LibraryPanelByUID("V--OrYHnz")
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -227,11 +224,10 @@ func TestLibraryPanelGetByUID(t *testing.T) {
 }
 
 func TestPatchLibraryPanel(t *testing.T) {
-	server, client := gapiTestToolsFromCalls(t, []mockServerCall{
+	client := gapiTestToolsFromCalls(t, []mockServerCall{
 		{200, getLibraryPanelUIDResponse},
 		{200, patchLibraryPanelResponse},
 	})
-	defer server.Close()
 
 	panel := LibraryPanel{
 		Folder: 1,
@@ -251,7 +247,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 
 		_, err := client.LibraryPanelByUID("V--OrYHnz")
 		if err == nil {
@@ -261,8 +257,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 }
 
 func TestLibraryPanelGetConnections(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getLibraryPanelConnectionsResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getLibraryPanelConnectionsResponse)
 
 	resp, err := client.LibraryPanelConnections("V--OrYHnz")
 	if err != nil {
@@ -275,8 +270,7 @@ func TestLibraryPanelGetConnections(t *testing.T) {
 }
 
 func TestLibraryPanelConnectedDashboards(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getLibraryPanelConnectionsResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getLibraryPanelConnectionsResponse)
 
 	connections, err := client.LibraryPanelConnections("V--OrYHnz")
 	if err != nil {
@@ -288,7 +282,7 @@ func TestLibraryPanelConnectedDashboards(t *testing.T) {
 		dashboardIds = append(dashboardIds, connection.DashboardID)
 	}
 
-	_, client = gapiTestTools(t, 200, getLibraryPanelConnectedDashboardsResponse)
+	client = gapiTestTools(t, 200, getLibraryPanelConnectedDashboardsResponse)
 	dashboards, err := client.DashboardsByIDs(dashboardIds)
 	if err != nil {
 		t.Fatal(err)
@@ -300,8 +294,7 @@ func TestLibraryPanelConnectedDashboards(t *testing.T) {
 }
 
 func TestLibraryPanelDelete(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deleteLibraryPanelResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deleteLibraryPanelResponse)
 
 	resp, err := client.DeleteLibraryPanel("V--OrYHnz")
 	if err != nil {

--- a/library_panel_test.go
+++ b/library_panel_test.go
@@ -176,7 +176,7 @@ func TestLibraryPanelCreate(t *testing.T) {
 	}
 
 	for _, code := range []int{400, 401, 403} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 		_, err = client.NewLibraryPanel(panel)
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -197,7 +197,7 @@ func TestLibraryPanelGetByName(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 		_, err = client.LibraryPanelByName("test")
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -218,7 +218,7 @@ func TestLibraryPanelGetByUID(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 		_, err = client.LibraryPanelByUID("V--OrYHnz")
 		if err == nil {
 			t.Errorf("%d not detected", code)
@@ -227,7 +227,10 @@ func TestLibraryPanelGetByUID(t *testing.T) {
 }
 
 func TestPatchLibraryPanel(t *testing.T) {
-	server, client := gapiTestTools(t, 200, patchLibraryPanelResponse)
+	server, client := gapiTestToolsFromCalls(t, []mockServerCall{
+		{200, getLibraryPanelUIDResponse},
+		{200, patchLibraryPanelResponse},
+	})
 	defer server.Close()
 
 	panel := LibraryPanel{
@@ -248,7 +251,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 	}
 
 	for _, code := range []int{401, 403, 404} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 
 		_, err := client.LibraryPanelByUID("V--OrYHnz")
 		if err == nil {

--- a/mock.go
+++ b/mock.go
@@ -23,11 +23,11 @@ func (m *mockServer) Close() {
 	m.server.Close()
 }
 
-func gapiTestTools(t *testing.T, code int, body string) (*mockServer, *Client) {
+func gapiTestTools(t *testing.T, code int, body string) *Client {
 	return gapiTestToolsFromCalls(t, []mockServerCall{{code, body}})
 }
 
-func gapiTestToolsFromCalls(t *testing.T, calls []mockServerCall) (*mockServer, *Client) {
+func gapiTestToolsFromCalls(t *testing.T, calls []mockServerCall) *Client {
 	t.Helper()
 
 	mock := &mockServer{
@@ -59,5 +59,10 @@ func gapiTestToolsFromCalls(t *testing.T, calls []mockServerCall) (*mockServer, 
 	if err != nil {
 		t.Fatal(err)
 	}
-	return mock, client
+
+	t.Cleanup(func() {
+		mock.Close()
+	})
+
+	return client
 }

--- a/mock.go
+++ b/mock.go
@@ -8,9 +8,15 @@ import (
 	"testing"
 )
 
+type mockServerCall struct {
+	code int
+	body string
+}
+
 type mockServer struct {
-	code   int
-	server *httptest.Server
+	upcomingCalls []mockServerCall
+	executedCalls []mockServerCall
+	server        *httptest.Server
 }
 
 func (m *mockServer) Close() {
@@ -18,16 +24,27 @@ func (m *mockServer) Close() {
 }
 
 func gapiTestTools(t *testing.T, code int, body string) (*mockServer, *Client) {
+	return gapiTestToolsFromCalls(t, []mockServerCall{{code, body}})
+}
+
+func gapiTestToolsFromCalls(t *testing.T, calls []mockServerCall) (*mockServer, *Client) {
 	t.Helper()
 
 	mock := &mockServer{
-		code: code,
+		upcomingCalls: calls,
 	}
 
 	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(mock.code)
+		call := mock.upcomingCalls[0]
+		if len(calls) > 1 {
+			mock.upcomingCalls = mock.upcomingCalls[1:]
+		} else {
+			mock.upcomingCalls = nil
+		}
+		w.WriteHeader(call.code)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, body)
+		fmt.Fprint(w, call.body)
+		mock.executedCalls = append(mock.executedCalls, call)
 	}))
 
 	tr := &http.Transport{

--- a/org_preferences_test.go
+++ b/org_preferences_test.go
@@ -10,8 +10,7 @@ const (
 )
 
 func TestOrgPreferences(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getOrgPreferencesJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getOrgPreferencesJSON)
 
 	resp, err := client.OrgPreferences()
 	if err != nil {
@@ -25,8 +24,7 @@ func TestOrgPreferences(t *testing.T) {
 }
 
 func TestUpdateOrgPreferences(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateOrgPreferencesJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateOrgPreferencesJSON)
 
 	resp, err := client.UpdateOrgPreferences(Preferences{
 		Theme: "foo",
@@ -42,8 +40,7 @@ func TestUpdateOrgPreferences(t *testing.T) {
 }
 
 func TestUpdateAllOrgPreference(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateOrgPreferencesJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateOrgPreferencesJSON)
 
 	resp, err := client.UpdateAllOrgPreferences(Preferences{
 		Theme: "foo",

--- a/org_users_test.go
+++ b/org_users_test.go
@@ -14,8 +14,7 @@ const (
 )
 
 func TestOrgUsersCurrent(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getOrgUsersJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getOrgUsersJSON)
 
 	resp, err := client.OrgUsersCurrent()
 	if err != nil {
@@ -36,8 +35,7 @@ func TestOrgUsersCurrent(t *testing.T) {
 }
 
 func TestOrgUsers(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getOrgUsersJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getOrgUsersJSON)
 
 	org := int64(1)
 	resp, err := client.OrgUsers(org)
@@ -61,8 +59,7 @@ func TestOrgUsers(t *testing.T) {
 }
 
 func TestAddOrgUser(t *testing.T) {
-	server, client := gapiTestTools(t, 200, addOrgUserJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, addOrgUserJSON)
 
 	orgID, user, role := int64(1), "admin@localhost", "Admin"
 
@@ -73,8 +70,7 @@ func TestAddOrgUser(t *testing.T) {
 }
 
 func TestUpdateOrgUser(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateOrgUserJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateOrgUserJSON)
 
 	orgID, userID, role := int64(1), int64(1), "Editor"
 
@@ -85,8 +81,7 @@ func TestUpdateOrgUser(t *testing.T) {
 }
 
 func TestRemoveOrgUser(t *testing.T) {
-	server, client := gapiTestTools(t, 200, removeOrgUserJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, removeOrgUserJSON)
 
 	orgID, userID := int64(1), int64(1)
 

--- a/orgs_test.go
+++ b/orgs_test.go
@@ -15,8 +15,7 @@ const (
 )
 
 func TestOrgs(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getOrgsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getOrgsJSON)
 
 	orgs, err := client.Orgs()
 	if err != nil {
@@ -34,8 +33,7 @@ func TestOrgs(t *testing.T) {
 }
 
 func TestOrgByName(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getOrgJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getOrgJSON)
 
 	org := "Main Org."
 	resp, err := client.OrgByName(org)
@@ -51,8 +49,7 @@ func TestOrgByName(t *testing.T) {
 }
 
 func TestOrg(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getOrgJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getOrgJSON)
 
 	org := int64(1)
 	resp, err := client.Org(org)
@@ -68,8 +65,7 @@ func TestOrg(t *testing.T) {
 }
 
 func TestNewOrg(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdOrgJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdOrgJSON)
 
 	resp, err := client.NewOrg("test-org")
 	if err != nil {
@@ -84,8 +80,7 @@ func TestNewOrg(t *testing.T) {
 }
 
 func TestUpdateOrg(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updatedOrgJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updatedOrgJSON)
 
 	err := client.UpdateOrg(int64(1), "test-org")
 	if err != nil {
@@ -94,8 +89,7 @@ func TestUpdateOrg(t *testing.T) {
 }
 
 func TestDeleteOrg(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deletedOrgJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deletedOrgJSON)
 
 	err := client.DeleteOrg(int64(1))
 	if err != nil {

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -38,7 +38,10 @@ const (
 )
 
 func TestPlaylistCreateAndUpdate(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createAndUpdatePlaylistResponse)
+	server, client := gapiTestToolsFromCalls(t, []mockServerCall{
+		{200, createAndUpdatePlaylistResponse},
+		{200, createAndUpdatePlaylistResponse},
+	})
 	defer server.Close()
 
 	playlist := Playlist{
@@ -97,6 +100,7 @@ func TestDeletePlaylist(t *testing.T) {
 
 	err := client.DeletePlaylist("1")
 	if err != nil {
+
 		t.Fatal(err)
 	}
 }

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -100,7 +100,6 @@ func TestDeletePlaylist(t *testing.T) {
 
 	err := client.DeletePlaylist("1")
 	if err != nil {
-
 		t.Fatal(err)
 	}
 }

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -38,11 +38,10 @@ const (
 )
 
 func TestPlaylistCreateAndUpdate(t *testing.T) {
-	server, client := gapiTestToolsFromCalls(t, []mockServerCall{
+	client := gapiTestToolsFromCalls(t, []mockServerCall{
 		{200, createAndUpdatePlaylistResponse},
 		{200, createAndUpdatePlaylistResponse},
 	})
-	defer server.Close()
 
 	playlist := Playlist{
 		Name:     "my playlist",
@@ -77,8 +76,7 @@ func TestPlaylistCreateAndUpdate(t *testing.T) {
 }
 
 func TestGetPlaylist(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getPlaylistResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getPlaylistResponse)
 
 	playlist, err := client.Playlist("2")
 	if err != nil {
@@ -95,8 +93,7 @@ func TestGetPlaylist(t *testing.T) {
 }
 
 func TestDeletePlaylist(t *testing.T) {
-	server, client := gapiTestTools(t, 200, "")
-	defer server.Close()
+	client := gapiTestTools(t, 200, "")
 
 	err := client.DeletePlaylist("1")
 	if err != nil {

--- a/report_test.go
+++ b/report_test.go
@@ -82,8 +82,7 @@ var (
 )
 
 func TestReport(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getReportJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getReportJSON)
 
 	report := int64(4)
 	resp, err := client.Report(report)
@@ -99,8 +98,7 @@ func TestReport(t *testing.T) {
 }
 
 func TestNewReport(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createReportJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createReportJSON)
 
 	resp, err := client.NewReport(testReport)
 	if err != nil {
@@ -115,8 +113,7 @@ func TestNewReport(t *testing.T) {
 }
 
 func TestUpdateReport(t *testing.T) {
-	server, client := gapiTestTools(t, 200, "")
-	defer server.Close()
+	client := gapiTestTools(t, 200, "")
 
 	err := client.UpdateReport(testReport)
 	if err != nil {
@@ -125,8 +122,7 @@ func TestUpdateReport(t *testing.T) {
 }
 
 func TestDeleteReport(t *testing.T) {
-	server, client := gapiTestTools(t, 200, "")
-	defer server.Close()
+	client := gapiTestTools(t, 200, "")
 
 	err := client.DeleteReport(4)
 	if err != nil {

--- a/role_test.go
+++ b/role_test.go
@@ -58,10 +58,7 @@ const (
 )
 
 func TestNewRole(t *testing.T) {
-	server, client := gapiTestTools(t, 201, newRoleResponse)
-	t.Cleanup(func() {
-		server.Close()
-	})
+	client := gapiTestTools(t, 201, newRoleResponse)
 
 	roleReq := Role{
 		Global:      false,
@@ -88,10 +85,7 @@ func TestNewRole(t *testing.T) {
 }
 
 func TestGetRole(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getRoleResponse)
-	t.Cleanup(func() {
-		server.Close()
-	})
+	client := gapiTestTools(t, 200, getRoleResponse)
 
 	uid := "vc3SCSsGz"
 
@@ -126,10 +120,7 @@ func TestGetRole(t *testing.T) {
 }
 
 func TestUpdateRole(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updatedRoleResponse)
-	t.Cleanup(func() {
-		server.Close()
-	})
+	client := gapiTestTools(t, 200, updatedRoleResponse)
 
 	roleReq := Role{
 		Global:      false,
@@ -150,10 +141,7 @@ func TestUpdateRole(t *testing.T) {
 }
 
 func TestDeleteRole(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deleteRoleResponse)
-	t.Cleanup(func() {
-		server.Close()
-	})
+	client := gapiTestTools(t, 200, deleteRoleResponse)
 
 	err := client.DeleteRole("vc3SCSsGz", false)
 	if err != nil {

--- a/service_account_test.go
+++ b/service_account_test.go
@@ -78,8 +78,7 @@ const (
 )
 
 func TestCreateServiceAccountToken(t *testing.T) {
-	server, client := gapiTestTools(t, http.StatusOK, createServiceAccountTokenJSON)
-	defer server.Close()
+	client := gapiTestTools(t, http.StatusOK, createServiceAccountTokenJSON)
 
 	req := CreateServiceAccountTokenRequest{
 		Name:          "key-name",
@@ -95,8 +94,7 @@ func TestCreateServiceAccountToken(t *testing.T) {
 }
 
 func TestCreateServiceAccount(t *testing.T) {
-	server, client := gapiTestTools(t, http.StatusOK, serviceAccountJSON)
-	defer server.Close()
+	client := gapiTestTools(t, http.StatusOK, serviceAccountJSON)
 
 	isDisabled := true
 	req := CreateServiceAccountRequest{
@@ -114,8 +112,7 @@ func TestCreateServiceAccount(t *testing.T) {
 }
 
 func TestUpdateServiceAccount(t *testing.T) {
-	server, client := gapiTestTools(t, http.StatusOK, serviceAccountJSON)
-	defer server.Close()
+	client := gapiTestTools(t, http.StatusOK, serviceAccountJSON)
 
 	isDisabled := false
 	req := UpdateServiceAccountRequest{
@@ -133,8 +130,7 @@ func TestUpdateServiceAccount(t *testing.T) {
 }
 
 func TestDeleteServiceAccount(t *testing.T) {
-	server, client := gapiTestTools(t, http.StatusOK, deleteServiceAccountJSON)
-	defer server.Close()
+	client := gapiTestTools(t, http.StatusOK, deleteServiceAccountJSON)
 
 	res, err := client.DeleteServiceAccount(int64(1))
 	if err != nil {
@@ -145,8 +141,7 @@ func TestDeleteServiceAccount(t *testing.T) {
 }
 
 func TestDeleteServiceAccountToken(t *testing.T) {
-	server, client := gapiTestTools(t, http.StatusOK, deleteServiceAccountTokenJSON)
-	defer server.Close()
+	client := gapiTestTools(t, http.StatusOK, deleteServiceAccountTokenJSON)
 
 	res, err := client.DeleteServiceAccountToken(int64(1), int64(1))
 	if err != nil {
@@ -157,8 +152,7 @@ func TestDeleteServiceAccountToken(t *testing.T) {
 }
 
 func TestGetServiceAccounts(t *testing.T) {
-	server, client := gapiTestTools(t, http.StatusOK, searchServiceAccountsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, http.StatusOK, searchServiceAccountsJSON)
 
 	res, err := client.GetServiceAccounts()
 	if err != nil {
@@ -169,8 +163,7 @@ func TestGetServiceAccounts(t *testing.T) {
 }
 
 func TestGetServiceAccountTokens(t *testing.T) {
-	server, client := gapiTestTools(t, http.StatusOK, getServiceAccountTokensJSON)
-	defer server.Close()
+	client := gapiTestTools(t, http.StatusOK, getServiceAccountTokensJSON)
 
 	res, err := client.GetServiceAccountTokens(5)
 	if err != nil {

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -17,8 +17,7 @@ const (
 )
 
 func TestSnapshotCreate(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdSnapshotResponse)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdSnapshotResponse)
 
 	snapshot := Snapshot{
 		Model: map[string]interface{}{
@@ -39,7 +38,7 @@ func TestSnapshotCreate(t *testing.T) {
 	}
 
 	for _, code := range []int{400, 401, 403, 412} {
-		_, client = gapiTestTools(t, code, "error")
+		client = gapiTestTools(t, code, "error")
 		_, err = client.NewSnapshot(snapshot)
 		if err == nil {
 			t.Errorf("%d not detected", code)

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -39,7 +39,7 @@ func TestSnapshotCreate(t *testing.T) {
 	}
 
 	for _, code := range []int{400, 401, 403, 412} {
-		server.code = code
+		_, client = gapiTestTools(t, code, "error")
 		_, err = client.NewSnapshot(snapshot)
 		if err == nil {
 			t.Errorf("%d not detected", code)

--- a/team_external_group_test.go
+++ b/team_external_group_test.go
@@ -30,8 +30,7 @@ const (
 )
 
 func TestTeamGroups(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getTeamGroupsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getTeamGroupsJSON)
 
 	teamID := int64(1)
 	teamGroups, err := client.TeamGroups(teamID)
@@ -50,8 +49,7 @@ func TestTeamGroups(t *testing.T) {
 }
 
 func TestNewTeamGroup(t *testing.T) {
-	server, client := gapiTestTools(t, 200, createdTeamGroupJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, createdTeamGroupJSON)
 
 	err := client.NewTeamGroup(int64(1), "test")
 	if err != nil {
@@ -60,8 +58,7 @@ func TestNewTeamGroup(t *testing.T) {
 }
 
 func TestDeleteTeamGroup(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deletedTeamGroupJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deletedTeamGroupJSON)
 
 	err := client.DeleteTeamGroup(int64(1), "test")
 	if err != nil {

--- a/teams_test.go
+++ b/teams_test.go
@@ -90,8 +90,7 @@ const (
 )
 
 func TestSearchTeam(t *testing.T) {
-	server, client := gapiTestTools(t, 200, searchTeamJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, searchTeamJSON)
 
 	query := "myteam"
 	resp, err := client.SearchTeam(query)
@@ -125,8 +124,7 @@ func TestSearchTeam(t *testing.T) {
 }
 
 func TestTeam(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getTeamJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getTeamJSON)
 
 	id := int64(1)
 	resp, err := client.Team(id)
@@ -153,8 +151,7 @@ func TestTeam(t *testing.T) {
 }
 
 func TestAddTeam(t *testing.T) {
-	server, client := gapiTestTools(t, 200, addTeamsJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, addTeamsJSON)
 
 	name := "TestTeam"
 	email := ""
@@ -169,8 +166,7 @@ func TestAddTeam(t *testing.T) {
 }
 
 func TestUpdateTeam(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateTeamJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateTeamJSON)
 
 	id := int64(1)
 	name := "TestTeam"
@@ -183,8 +179,7 @@ func TestUpdateTeam(t *testing.T) {
 }
 
 func TestDeleteTeam(t *testing.T) {
-	server, client := gapiTestTools(t, 200, deleteTeamJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, deleteTeamJSON)
 
 	id := int64(1)
 
@@ -195,8 +190,7 @@ func TestDeleteTeam(t *testing.T) {
 }
 
 func TestTeamMembers(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getTeamMembersJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getTeamMembersJSON)
 
 	id := int64(1)
 
@@ -235,8 +229,7 @@ func TestTeamMembers(t *testing.T) {
 }
 
 func TestAddTeamMember(t *testing.T) {
-	server, client := gapiTestTools(t, 200, addTeamMemberJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, addTeamMemberJSON)
 
 	id := int64(1)
 	userID := int64(2)
@@ -247,8 +240,7 @@ func TestAddTeamMember(t *testing.T) {
 }
 
 func TestRemoveMemberFromTeam(t *testing.T) {
-	server, client := gapiTestTools(t, 200, removeMemberFromTeamJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, removeMemberFromTeamJSON)
 
 	id := int64(1)
 	userID := int64(2)
@@ -259,8 +251,7 @@ func TestRemoveMemberFromTeam(t *testing.T) {
 }
 
 func TestTeamPreferences(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getTeamPreferencesJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getTeamPreferencesJSON)
 
 	id := int64(1)
 
@@ -282,8 +273,7 @@ func TestTeamPreferences(t *testing.T) {
 }
 
 func TestUpdateTeamPreferences(t *testing.T) {
-	server, client := gapiTestTools(t, 200, updateTeamPreferencesJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, updateTeamPreferencesJSON)
 
 	id := int64(1)
 	preferences := Preferences{

--- a/user_test.go
+++ b/user_test.go
@@ -14,8 +14,7 @@ const (
 )
 
 func TestUsers(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getUsersJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getUsersJSON)
 
 	resp, err := client.Users()
 	if err != nil {
@@ -38,8 +37,7 @@ func TestUsers(t *testing.T) {
 }
 
 func TestUser(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getUserJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getUserJSON)
 
 	user, err := client.User(1)
 	if err != nil {
@@ -56,8 +54,7 @@ func TestUser(t *testing.T) {
 }
 
 func TestUserByEmail(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getUserByEmailJSON)
-	defer server.Close()
+	client := gapiTestTools(t, 200, getUserByEmailJSON)
 
 	user, err := client.UserByEmail("admin@localhost")
 	if err != nil {
@@ -74,11 +71,10 @@ func TestUserByEmail(t *testing.T) {
 }
 
 func TestUserUpdate(t *testing.T) {
-	server, client := gapiTestToolsFromCalls(t, []mockServerCall{
+	client := gapiTestToolsFromCalls(t, []mockServerCall{
 		{200, getUserJSON},
 		{200, getUserUpdateJSON},
 	})
-	defer server.Close()
 
 	user, err := client.User(4)
 	if err != nil {

--- a/user_test.go
+++ b/user_test.go
@@ -74,7 +74,10 @@ func TestUserByEmail(t *testing.T) {
 }
 
 func TestUserUpdate(t *testing.T) {
-	server, client := gapiTestTools(t, 200, getUserUpdateJSON)
+	server, client := gapiTestToolsFromCalls(t, []mockServerCall{
+		{200, getUserJSON},
+		{200, getUserUpdateJSON},
+	})
 	defer server.Close()
 
 	user, err := client.User(4)


### PR DESCRIPTION
Will be used for https://github.com/grafana/grafana-api-golang-client/pull/119. 
Currently, the test suite never ends because it's not possible to define a list of calls. In a paginated API context, it can only keep returning the first page forever