### PR TITLE
Paginate Dashboards().

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -75,10 +75,32 @@ func (c *Client) NewDashboard(dashboard Dashboard) (*DashboardSaveResponse, erro
 
 // Dashboards fetches and returns all dashboards.
 func (c *Client) Dashboards() ([]FolderDashboardSearchResponse, error) {
-	params := url.Values{
-		"type": {"dash-db"},
+	const limit = 1000
+
+	var (
+		page          = 0
+		newDashboards []FolderDashboardSearchResponse
+		dashboards    []FolderDashboardSearchResponse
+		query         = make(url.Values)
+	)
+
+	query.Set("type", fmt.Sprint("dash-db"))
+	query.Set("limit", fmt.Sprint(limit))
+
+	for {
+		page++
+		query.Set("page", fmt.Sprint(page))
+
+		if err := c.request("GET", "/api/search", query, nil, &newDashboards); err != nil {
+			return nil, err
+		}
+
+		dashboards = append(dashboards, newDashboards...)
+
+		if len(newDashboards) < limit {
+			return dashboards, nil
+		}
 	}
-	return c.FolderDashboardSearch(params)
 }
 
 // Dashboard will be removed.

--- a/dashboard.go
+++ b/dashboard.go
@@ -84,7 +84,7 @@ func (c *Client) Dashboards() ([]FolderDashboardSearchResponse, error) {
 		query         = make(url.Values)
 	)
 
-	query.Set("type", fmt.Sprint("dash-db"))
+	query.Set("type", "dash-db")
 	query.Set("limit", fmt.Sprint(limit))
 
 	for {


### PR DESCRIPTION
If you have more than 1000 dashboards, the `Dashboards()` method does not return them all. This fixes that problem. Unlike #119, this does not make a final call to retrieve an empty payload from Grafana [unless there is exactly a multiple of 1000 dashboards on the server].