### PR TITLE
Add DashboardVersion methods, and more test paths.

### DIFF
--- a/alertnotification.go
+++ b/alertnotification.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // AlertNotification represents a Grafana alert notification.
@@ -17,6 +18,7 @@ type AlertNotification struct {
 	DisableResolveMessage bool        `json:"disableResolveMessage"`
 	SendReminder          bool        `json:"sendReminder"`
 	Frequency             string      `json:"frequency"`
+	Created               time.Time   `json:"created"`
 	Settings              interface{} `json:"settings"`
 	SecureFields          interface{} `json:"secureFields,omitempty"`
 	SecureSettings        interface{} `json:"secureSettings,omitempty"`

--- a/client.go
+++ b/client.go
@@ -17,6 +17,11 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 )
 
+var (
+	// ErrInvalidStatus is returned when Grafana replies with an HTTP status code > 400.
+	ErrInvalidStatus = fmt.Errorf("invalid status")
+)
+
 // Client is a Grafana API client.
 type Client struct {
 	config  Config
@@ -127,8 +132,8 @@ func (c *Client) request(method, requestPath string, query url.Values, body io.R
 	}
 
 	// check status code.
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("status: %d, body: %v", resp.StatusCode, string(bodyContents))
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("%w: %d, body: %v", ErrInvalidStatus, resp.StatusCode, string(bodyContents))
 	}
 
 	if responseStruct == nil {

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package gapi
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/url"
 	"testing"
 )
@@ -100,20 +101,28 @@ func TestRequest_201(t *testing.T) {
 func TestRequest_400(t *testing.T) {
 	client := gapiTestTools(t, 400, `{"foo":"bar"}`)
 
-	expected := `status: 400, body: {"foo":"bar"}`
+	expected := `invalid status: 400, body: {"foo":"bar"}`
 	err := client.request("GET", "/foo", url.Values{}, nil, nil)
 	if err.Error() != expected {
 		t.Errorf("expected error: %v; got: %s", expected, err)
+	}
+
+	if !errors.Is(err, ErrInvalidStatus) {
+		t.Errorf("expected error: %v; got: %s", ErrInvalidStatus, err)
 	}
 }
 
 func TestRequest_500(t *testing.T) {
 	client := gapiTestTools(t, 500, `{"foo":"bar"}`)
 
-	expected := `status: 500, body: {"foo":"bar"}`
+	expected := `invalid status: 500, body: {"foo":"bar"}`
 	err := client.request("GET", "/foo", url.Values{}, nil, nil)
 	if err.Error() != expected {
 		t.Errorf("expected error: %v; got: %s", expected, err)
+	}
+
+	if !errors.Is(err, ErrInvalidStatus) {
+		t.Errorf("expected error: %v; got: %s", ErrInvalidStatus, err)
 	}
 }
 

--- a/cloud_plugin.go
+++ b/cloud_plugin.go
@@ -80,7 +80,7 @@ func (c *Client) IsCloudPluginInstalled(stackSlug string, pluginSlug string) (bo
 			return false, err
 		}
 
-		return false, fmt.Errorf("status: %d, body: %v", resp.StatusCode, string(bodyContents))
+		return false, fmt.Errorf("%w: %d, body: %v", ErrInvalidStatus, resp.StatusCode, string(bodyContents))
 	}
 
 	return true, nil

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -146,9 +146,9 @@ func TestDashboards(t *testing.T) {
 
 	// This creates 1000 + 1000 + 1 (2001, 3 calls) worth of dashboards.
 	client := gapiTestToolsFromCalls(t, []mockServerCall{
-		{200, mockData},
-		{200, mockData},
-		{200, "[" + getDashboardsJSON + "]"},
+		{code: 200, body: mockData},
+		{code: 200, body: mockData},
+		{code: 200, body: "[" + getDashboardsJSON + "]"},
 	})
 
 	const dashCount = 2001

--- a/dashboard_versions.go
+++ b/dashboard_versions.go
@@ -50,7 +50,7 @@ type CompareDashboardsInput struct {
 // DashboardVersions returns all dashboard versions for a specific dashboard UID.
 // limit = Maximum number of results to return,
 // start = Version to start from when returning queries.
-func (c *Client) DashboardVersions(dashboardUID string, limit, start int) ([]*DashboardVersion, error) {
+func (c *Client) DashboardVersions(dashboardUID string, limit, start int64) ([]*DashboardVersion, error) {
 	var (
 		params = make(url.Values)
 		result = []*DashboardVersion{}
@@ -69,7 +69,7 @@ func (c *Client) DashboardVersions(dashboardUID string, limit, start int) ([]*Da
 
 // DashboardVersion returns a single dashboard version for a specific dashboard UID.
 // version = The version number to return. Empty data is returned if it does not exist.
-func (c *Client) DashboardVersion(dashboardUID string, version int) (*DashboardVersion, error) {
+func (c *Client) DashboardVersion(dashboardUID string, version int64) (*DashboardVersion, error) {
 	var (
 		params = make(url.Values)
 		result = DashboardVersion{}
@@ -85,7 +85,7 @@ func (c *Client) DashboardVersion(dashboardUID string, version int) (*DashboardV
 
 // RestoreDashboardVersion restores a dashboard version for a specific dashboard UID.
 // version = The version number to restore.
-func (c *Client) RestoreDashboardVersion(dashboardUID string, version int) (*DashboardVersionRestore, error) {
+func (c *Client) RestoreDashboardVersion(dashboardUID string, version int64) (*DashboardVersionRestore, error) {
 	var (
 		params = make(url.Values)
 		result = DashboardVersionRestore{}

--- a/dashboard_versions.go
+++ b/dashboard_versions.go
@@ -1,0 +1,156 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// DashboardVersion is the data returned from the GetDashboardVersion* methods.
+type DashboardVersion struct {
+	ID            int64  `json:"id"`
+	DashboardID   int64  `json:"dashboardId"`
+	UID           string `json:"uid"`
+	ParentVersion int64  `json:"parentVersion"`
+	RestoredFrom  int64  `json:"restoredFrom"`
+	Version       int64  `json:"version"`
+	Created       string `json:"created"`
+	CreatedBy     string `json:"createdBy"`
+	Message       string `json:"message"`
+	// Data is the dashboard model, and only gets filled when a single version is requested.
+	Data map[string]interface{} `json:"data"`
+}
+
+// DashboardVersionRestore is the returned data from restoring a dashboard.
+// slug = The URL friendly slug of the dashboard’s title,
+// status = Whether the restoration was successful or not,
+// version = The new dashboard version, following the restoration.
+type DashboardVersionRestore struct {
+	ID      int64  `json:"id"`      // 70
+	Slug    string `json:"slug"`    // my-dashboard
+	Status  string `json:"status"`  // success
+	UID     string `json:"uid"`     // QA7wKklGz
+	URL     string `json:"url"`     // /d/QA7wKklGz/my-dashboard
+	Version int64  `json:"version"` // 3
+}
+
+// CompareDashboardsInput is the required input when comparing dashboards.
+type CompareDashboardsInput struct {
+	BaseDashboardID      int64
+	BaseDashboardVersion int64
+	NewDashboardID       int64
+	NewDashboardVersion  int64
+	// DiffType may be 'json' or 'basic'. Default is 'basic'.
+	DiffType string
+}
+
+// GetDashboardVersions returns all dashboard versions for a specific dashboard UID.
+// limit = Maximum number of results to return,
+// start = Version to start from when returning queries.
+func (c *Client) GetDashboardVersions(dashboardUID string, limit, start int) ([]*DashboardVersion, error) {
+	var (
+		params = make(url.Values)
+		result = []*DashboardVersion{}
+		path   = fmt.Sprintf("/api/dashboards/uid/%s/versions", dashboardUID)
+	)
+
+	params.Set("limit", fmt.Sprint(limit))
+	params.Set("start", fmt.Sprint(start))
+
+	if err := c.request(http.MethodGet, path, params, nil, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetDashboardVersion returns a single dashboard version for a specific dashboard UID.
+// version = The version number to return. Empty data is returned if it does not exist.
+func (c *Client) GetDashboardVersion(dashboardUID string, version int) (*DashboardVersion, error) {
+	var (
+		params = make(url.Values)
+		result = DashboardVersion{}
+		path   = fmt.Sprintf("/api/dashboards/uid/%s/versions/%d", dashboardUID, version)
+	)
+
+	if err := c.request(http.MethodGet, path, params, nil, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// RestoreDashboardVersion restores a dashboard version for a specific dashboard UID.
+// version = The version number to restore.
+func (c *Client) RestoreDashboardVersion(dashboardUID string, version int) (*DashboardVersionRestore, error) {
+	var (
+		params = make(url.Values)
+		result = DashboardVersionRestore{}
+		path   = fmt.Sprintf("/api/dashboards/uid/%s/restore", dashboardUID)
+		body   = bytes.NewBufferString(fmt.Sprintf(`{"version":%d}`, version))
+	)
+
+	if err := c.request(http.MethodPost, path, params, body, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// CompareDashboardVersions compares two different dashboard versions. Can even compare different dashboards IDs.
+// Returns "text" (formatted html) not json. You can wrap the []byte in string() to convert it.
+func (c *Client) CompareDashboardVersions(compareDashboards CompareDashboardsInput) ([]byte, error) {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(compareDashboards); err != nil {
+		return nil, fmt.Errorf("json encoding input: %w", err)
+	}
+
+	req, err := c.newRequest(http.MethodPost, "/api/dashboards/calculate-diff", url.Values{}, &body)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyContents, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading body: %w", err)
+	}
+
+	// check status code.
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("%w: %d, body: %v", ErrInvalidStatus, resp.StatusCode, string(bodyContents))
+	}
+
+	return bodyContents, nil
+}
+
+// MarshalJSON turns a CompareDashboardsInput into the json Grafana requires.
+func (c CompareDashboardsInput) MarshalJSON() ([]byte, error) {
+	type dashboard struct {
+		ID      int64 `json:"dashboardId"`
+		Version int64 `json:"version"`
+	}
+
+	diffType := c.DiffType
+	if diffType == "" {
+		diffType = "basic"
+	}
+
+	return json.Marshal(&struct {
+		Base dashboard `json:"base"`
+		New  dashboard `json:"new"`
+		Type string    `json:"diffType"`
+	}{
+		Base: dashboard{ID: c.BaseDashboardID, Version: c.BaseDashboardVersion},
+		New:  dashboard{ID: c.NewDashboardID, Version: c.NewDashboardVersion},
+		Type: diffType,
+	})
+}

--- a/dashboard_versions.go
+++ b/dashboard_versions.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -119,7 +119,7 @@ func (c *Client) CompareDashboardVersions(compareDashboards CompareDashboardsInp
 	}
 	defer resp.Body.Close()
 
-	bodyContents, err := io.ReadAll(resp.Body)
+	bodyContents, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading body: %w", err)
 	}

--- a/dashboard_versions.go
+++ b/dashboard_versions.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 )
 
-// DashboardVersion is the data returned from the GetDashboardVersion* methods.
+// DashboardVersion is the data returned from the DashboardVersion* methods.
 type DashboardVersion struct {
 	ID            int64  `json:"id"`
 	DashboardID   int64  `json:"dashboardId"`
@@ -47,10 +47,10 @@ type CompareDashboardsInput struct {
 	DiffType string
 }
 
-// GetDashboardVersions returns all dashboard versions for a specific dashboard UID.
+// DashboardVersions returns all dashboard versions for a specific dashboard UID.
 // limit = Maximum number of results to return,
 // start = Version to start from when returning queries.
-func (c *Client) GetDashboardVersions(dashboardUID string, limit, start int) ([]*DashboardVersion, error) {
+func (c *Client) DashboardVersions(dashboardUID string, limit, start int) ([]*DashboardVersion, error) {
 	var (
 		params = make(url.Values)
 		result = []*DashboardVersion{}
@@ -67,9 +67,9 @@ func (c *Client) GetDashboardVersions(dashboardUID string, limit, start int) ([]
 	return result, nil
 }
 
-// GetDashboardVersion returns a single dashboard version for a specific dashboard UID.
+// DashboardVersion returns a single dashboard version for a specific dashboard UID.
 // version = The version number to return. Empty data is returned if it does not exist.
-func (c *Client) GetDashboardVersion(dashboardUID string, version int) (*DashboardVersion, error) {
+func (c *Client) DashboardVersion(dashboardUID string, version int) (*DashboardVersion, error) {
 	var (
 		params = make(url.Values)
 		result = DashboardVersion{}

--- a/dashboard_versions_test.go
+++ b/dashboard_versions_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	// This must be wraoped in [] to make it a list.
+	// This must be wrapped in [] to make it a list.
 	getDashboardVersionsResponse = `{
 		"id": 2,
 		"dashboardId": 1,
@@ -87,7 +87,7 @@ func TestGetDashboardVersions(t *testing.T) {
 		reqMethod: http.MethodGet,
 	}})
 
-	dashboardVersions, err := client.GetDashboardVersions("QA7wKklGz", count, 0)
+	dashboardVersions, err := client.DashboardVersions("QA7wKklGz", count, 0)
 	if err != nil {
 		t.Errorf("did not expect an error: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestGetDashboardVersion(t *testing.T) {
 		reqMethod: http.MethodGet,
 	}})
 
-	dashboard, err := client.GetDashboardVersion("QA7wKklGz", 45)
+	dashboard, err := client.DashboardVersion("QA7wKklGz", 45)
 	if err != nil {
 		t.Errorf("did not expect an error from dashboard version: %v", err)
 	}

--- a/dashboard_versions_test.go
+++ b/dashboard_versions_test.go
@@ -151,7 +151,7 @@ func TestCompareDashboardVersions(t *testing.T) {
 		body:      compareDashboardsResponse,
 		reqURI:    "/api/dashboards/calculate-diff",
 		reqMethod: http.MethodPost,
-		reqBody:   `{"base":{"dashboardId":1,"version":2},"new":{"dashboardId":3,"version":4},"diffType":"json"}`,
+		reqBody:   `{"base":{"dashboardId":1,"version":2},"new":{"dashboardId":3,"version":4},"diffType":"basic"}`,
 	}})
 
 	compare, err := client.CompareDashboardVersions(CompareDashboardsInput{
@@ -159,7 +159,6 @@ func TestCompareDashboardVersions(t *testing.T) {
 		BaseDashboardVersion: 2,
 		NewDashboardID:       3,
 		NewDashboardVersion:  4,
-		DiffType:             "json",
 	})
 	if err != nil {
 		t.Errorf("did not expect an error from dashboard compare: %v", err)

--- a/dashboard_versions_test.go
+++ b/dashboard_versions_test.go
@@ -164,7 +164,7 @@ func TestCompareDashboardVersions(t *testing.T) {
 		t.Errorf("did not expect an error from dashboard compare: %v", err)
 	}
 
-	if string(compare) != compareDashboardsResponse {
+	if compare != compareDashboardsResponse {
 		t.Error("got wrong responnse from dashboard compare")
 	}
 }

--- a/dashboard_versions_test.go
+++ b/dashboard_versions_test.go
@@ -1,0 +1,171 @@
+package gapi
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const (
+	// This must be wraoped in [] to make it a list.
+	getDashboardVersionsResponse = `{
+		"id": 2,
+		"dashboardId": 1,
+		"uid": "QA7wKklGz",
+		"parentVersion": 1,
+		"restoredFrom": 0,
+		"version": 2,
+		"created": "2017-06-08T17:24:33-04:00",
+		"createdBy": "admin",
+		"message": "Updated panel title"
+	  }`
+	getDashboardVersionResponse = `{
+		"id": 1,
+		"dashboardId": 1,
+		"uid": "QA7wKklGz",
+		"parentVersion": 0,
+		"restoredFrom": 0,
+		"version": 1,
+		"created": "2017-04-26T17:18:38-04:00",
+		"message": "Initial save",
+		"data": {
+		  "annotations": {"list": []},
+		  "editable": true,
+		  "gnetId": null,
+		  "graphTooltip": 0,
+		  "id": 1,
+		  "links": [],
+		  "rows": [
+			{
+			  "collapse": false,
+			  "height": "250px",
+			  "panels": [],
+			  "repeat": null,
+			  "repeatIteration": null,
+			  "repeatRowId": null,
+			  "showTitle": false,
+			  "title": "Dashboard Row",
+			  "titleSize": "h6"
+			}
+		  ],
+		  "schemaVersion": 14,
+		  "style": "dark",
+		  "tags": [  ],
+		  "templating": {"list": []},
+		  "time": {"from": "now-6h","to": "now"},
+		  "timepicker": {
+			"refresh_intervals": ["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"],
+			"time_options": ["5m","15m","1h","6h","12h","24h","2d","7d","30d"]
+		  },
+		  "timezone": "browser",
+		  "title": "test",
+		  "version": 1
+		},
+		"createdBy": "admin"
+	  }`
+	restoreDashboardResponse = `{
+		"id": 70,
+		"slug": "my-dashboard",
+		"status": "success",
+		"uid": "QA7wKklGz",
+		"url": "/d/QA7wKklGz/my-dashboard",
+		"version": 54
+	  }`
+	compareDashboardsResponse = `<html>stuff</html>`
+)
+
+func TestGetDashboardVersions(t *testing.T) {
+	t.Parallel()
+
+	const count = 20
+
+	versions := strings.Repeat(getDashboardVersionsResponse+",", count)
+	client := gapiTestToolsFromCalls(t, []mockServerCall{{
+		code:      200,
+		body:      "[" + strings.TrimSuffix(versions, ",") + "]",
+		reqURI:    "/api/dashboards/uid/QA7wKklGz/versions?limit=20&start=0",
+		reqMethod: http.MethodGet,
+	}})
+
+	dashboardVersions, err := client.GetDashboardVersions("QA7wKklGz", count, 0)
+	if err != nil {
+		t.Errorf("did not expect an error: %v", err)
+	}
+
+	if len(dashboardVersions) != count {
+		t.Errorf("wrong dashboard version count returned, expected %d, got %d", count, len(dashboardVersions))
+	}
+}
+
+func TestGetDashboardVersion(t *testing.T) {
+	t.Parallel()
+	client := gapiTestToolsFromCalls(t, []mockServerCall{{
+		code:      200,
+		body:      getDashboardVersionResponse,
+		reqURI:    "/api/dashboards/uid/QA7wKklGz/versions/45",
+		reqMethod: http.MethodGet,
+	}})
+
+	dashboard, err := client.GetDashboardVersion("QA7wKklGz", 45)
+	if err != nil {
+		t.Errorf("did not expect an error from dashboard version: %v", err)
+	}
+
+	if dashboard == nil {
+		t.Fatal("dashboard version must not be nil")
+	}
+
+	if dashboard.CreatedBy != "admin" {
+		t.Error("dashboard version data seems invalid")
+	}
+}
+
+func TestRestoreDashboardVersion(t *testing.T) {
+	t.Parallel()
+	client := gapiTestToolsFromCalls(t, []mockServerCall{{
+		code:      200,
+		body:      restoreDashboardResponse,
+		reqURI:    "/api/dashboards/uid/QA7wKklGz/restore",
+		reqMethod: http.MethodPost,
+		reqBody:   `{"version":54}`,
+	}})
+
+	dashboard, err := client.RestoreDashboardVersion("QA7wKklGz", 54)
+	if err != nil {
+		t.Errorf("did not expect an error from dashboard restore: %v", err)
+	}
+
+	if dashboard == nil {
+		t.Fatal("dashboard restore data must not be nil")
+	}
+
+	if dashboard.Version != 54 {
+		t.Error("restored dashboard version data seems invalid")
+	}
+}
+
+func TestCompareDashboardVersions(t *testing.T) {
+	t.Parallel()
+	client := gapiTestToolsFromCalls(t, []mockServerCall{{
+		code:      200,
+		body:      compareDashboardsResponse,
+		reqURI:    "/api/dashboards/calculate-diff",
+		reqMethod: http.MethodPost,
+		reqBody:   `{"base":{"dashboardId":1,"version":2},"new":{"dashboardId":3,"version":4},"diffType":"json"}`,
+	}})
+
+	compare, err := client.CompareDashboardVersions(CompareDashboardsInput{
+		BaseDashboardID:      1,
+		BaseDashboardVersion: 2,
+		NewDashboardID:       3,
+		NewDashboardVersion:  4,
+		DiffType:             "json",
+	})
+	if err != nil {
+		t.Errorf("did not expect an error from dashboard compare: %v", err)
+	}
+
+	if string(compare) != compareDashboardsResponse {
+		t.Error("got wrong responnse from dashboard compare")
+	}
+}

--- a/folder_test.go
+++ b/folder_test.go
@@ -87,9 +87,9 @@ func TestFolders(t *testing.T) {
 
 	// This creates 1000 + 1000 + 1 (2001, 3 calls) worth of folders.
 	client := gapiTestToolsFromCalls(t, []mockServerCall{
-		{200, mockData},
-		{200, mockData},
-		{200, "[" + getFolderJSON + "]"},
+		{code: 200, body: mockData},
+		{code: 200, body: mockData},
+		{code: 200, body: "[" + getFolderJSON + "]"},
 	})
 
 	const dashCount = 2001

--- a/library_panel_test.go
+++ b/library_panel_test.go
@@ -225,8 +225,8 @@ func TestLibraryPanelGetByUID(t *testing.T) {
 
 func TestPatchLibraryPanel(t *testing.T) {
 	client := gapiTestToolsFromCalls(t, []mockServerCall{
-		{200, getLibraryPanelUIDResponse},
-		{200, patchLibraryPanelResponse},
+		{code: 200, body: getLibraryPanelUIDResponse},
+		{code: 200, body: patchLibraryPanelResponse},
 	})
 
 	panel := LibraryPanel{

--- a/mock.go
+++ b/mock.go
@@ -2,7 +2,7 @@ package gapi
 
 import (
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -91,7 +91,7 @@ func (c mockServerCall) testRequestData(t *testing.T, req *http.Request) {
 		return
 	}
 
-	reqBody, err := io.ReadAll(req.Body)
+	reqBody, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		t.Errorf("got unexpected error reading request body: %v", err)
 	}

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -39,8 +39,8 @@ const (
 
 func TestPlaylistCreateAndUpdate(t *testing.T) {
 	client := gapiTestToolsFromCalls(t, []mockServerCall{
-		{200, createAndUpdatePlaylistResponse},
-		{200, createAndUpdatePlaylistResponse},
+		{code: 200, body: createAndUpdatePlaylistResponse},
+		{code: 200, body: createAndUpdatePlaylistResponse},
 	})
 
 	playlist := Playlist{

--- a/user_test.go
+++ b/user_test.go
@@ -15,8 +15,8 @@ const (
 
 func TestUsers(t *testing.T) {
 	client := gapiTestToolsFromCalls(t, []mockServerCall{
-		{200, getUsersJSON},
-		{200, "null"},
+		{code: 200, body: getUsersJSON},
+		{code: 200, body: "null"},
 	})
 
 	resp, err := client.Users()
@@ -75,8 +75,8 @@ func TestUserByEmail(t *testing.T) {
 
 func TestUserUpdate(t *testing.T) {
 	client := gapiTestToolsFromCalls(t, []mockServerCall{
-		{200, getUserJSON},
-		{200, getUserUpdateJSON},
+		{code: 200, body: getUserJSON},
+		{code: 200, body: getUserUpdateJSON},
 	})
 
 	user, err := client.User(4)


### PR DESCRIPTION
~~I still need to integration test these new methods locally, but this code is mostly there and I wanted to share for review and feedback. I'll mark this as ready for review after I look at it again, sleep, and do testing. Probably not in that order though.~~ **This has been locally tested with an integration app and all methods work correctly.**

- Adds all 4 non-deprecated dashboard version methods [documented here](https://grafana.com/docs/grafana/v9.3/developers/http_api/dashboard_versions/).
- Includes minimal tests for new methods.
- Replaces several dynamic errors with a new static error; `ErrInvalidStatus`.
  - I did this because I needed to use it in one of the new methods, and dynamic errors are hard for consumers to use.
  - Adds to - and updates - the existing tests for this returned error.
- Creates new test-paths in mock.go to allow 'checking' the request data.
- The new (dashboard version) methods' tests use the new test-paths for more thorough testing.