### PR TITLE
Add methods to manage dashboard permissions by UID

### DIFF
--- a/dashboard_permissions.go
+++ b/dashboard_permissions.go
@@ -45,3 +45,25 @@ func (c *Client) UpdateDashboardPermissions(id int64, items *PermissionItems) er
 
 	return c.request("POST", path, nil, bytes.NewBuffer(data), nil)
 }
+
+// DashboardPermissionsByUID fetches and returns the permissions for the dashboard whose UID it's passed.
+func (c *Client) DashboardPermissionsByUID(uid string) ([]*DashboardPermission, error) {
+	permissions := make([]*DashboardPermission, 0)
+	err := c.request("GET", fmt.Sprintf("/api/dashboards/uid/%s/permissions", uid), nil, nil, &permissions)
+	if err != nil {
+		return permissions, err
+	}
+
+	return permissions, nil
+}
+
+// UpdateDashboardPermissionsByUID remove existing permissions if items are not included in the request.
+func (c *Client) UpdateDashboardPermissionsByUID(uid string, items *PermissionItems) error {
+	path := fmt.Sprintf("/api/dashboards/uid/%s/permissions", uid)
+	data, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+
+	return c.request("POST", path, nil, bytes.NewBuffer(data), nil)
+}

--- a/dashboard_permissions.go
+++ b/dashboard_permissions.go
@@ -28,11 +28,7 @@ type DashboardPermission struct {
 func (c *Client) DashboardPermissions(id int64) ([]*DashboardPermission, error) {
 	permissions := make([]*DashboardPermission, 0)
 	err := c.request("GET", fmt.Sprintf("/api/dashboards/id/%d/permissions", id), nil, nil, &permissions)
-	if err != nil {
-		return permissions, err
-	}
-
-	return permissions, nil
+	return permissions, err
 }
 
 // UpdateDashboardPermissions remove existing permissions if items are not included in the request.
@@ -50,11 +46,7 @@ func (c *Client) UpdateDashboardPermissions(id int64, items *PermissionItems) er
 func (c *Client) DashboardPermissionsByUID(uid string) ([]*DashboardPermission, error) {
 	permissions := make([]*DashboardPermission, 0)
 	err := c.request("GET", fmt.Sprintf("/api/dashboards/uid/%s/permissions", uid), nil, nil, &permissions)
-	if err != nil {
-		return permissions, err
-	}
-
-	return permissions, nil
+	return permissions, err
 }
 
 // UpdateDashboardPermissionsByUID remove existing permissions if items are not included in the request.

--- a/dashboard_permissions_test.go
+++ b/dashboard_permissions_test.go
@@ -136,3 +136,84 @@ func TestUpdateDashboardPermissions(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestDashboardPermissionsByUID(t *testing.T) {
+	client := gapiTestTools(t, 200, getDashboardPermissionsJSON)
+
+	resp, err := client.DashboardPermissionsByUID("nErXDvCkzz")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(pretty.PrettyFormat(resp))
+
+	expects := []*DashboardPermission{
+		{
+			DashboardID:    1,
+			DashboardUID:   "nErXDvCkzz",
+			Role:           "Viewer",
+			UserID:         0,
+			TeamID:         0,
+			IsFolder:       false,
+			Inherited:      false,
+			Permission:     1,
+			PermissionName: "View",
+		},
+		{
+			DashboardID:    2,
+			DashboardUID:   "nErXDvCkzz",
+			Role:           "Editor",
+			UserID:         0,
+			TeamID:         0,
+			IsFolder:       false,
+			Inherited:      true,
+			Permission:     2,
+			PermissionName: "Edit",
+		},
+	}
+
+	for i, expect := range expects {
+		t.Run("check data", func(t *testing.T) {
+			if resp[i].DashboardID != expect.DashboardID ||
+				resp[i].DashboardUID != expect.DashboardUID ||
+				resp[i].Role != expect.Role ||
+				resp[i].UserID != expect.UserID ||
+				resp[i].TeamID != expect.TeamID ||
+				resp[i].IsFolder != expect.IsFolder ||
+				resp[i].Inherited != expect.Inherited ||
+				resp[i].Permission != expect.Permission ||
+				resp[i].PermissionName != expect.PermissionName {
+				t.Error("Not correctly parsing returned dashboard permission")
+			}
+		})
+	}
+}
+
+func TestUpdateDashboardPermissionsByUID(t *testing.T) {
+	client := gapiTestTools(t, 200, updateDashboardPermissionsJSON)
+
+	items := &PermissionItems{
+		Items: []*PermissionItem{
+			{
+				Role:       "viewer",
+				Permission: 1,
+			},
+			{
+				Role:       "Editor",
+				Permission: 2,
+			},
+			{
+				TeamID:     1,
+				Permission: 1,
+			},
+			{
+				UserID:     11,
+				Permission: 4,
+			},
+		},
+	}
+	err := client.UpdateDashboardPermissionsByUID("nErXDvCkzz", items)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Using the ID is deprecated since Grafana v9
We should switch to UIDs in the Terraform provider