### PR TITLE
Add cloud org resource

### DIFF
--- a/cloud_org.go
+++ b/cloud_org.go
@@ -1,0 +1,21 @@
+package gapi
+
+import (
+	"fmt"
+	"time"
+)
+
+type CloudOrg struct {
+	ID        int64     `json:"id"`
+	Slug      string    `json:"slug"`
+	Name      string    `json:"name"`
+	URL       string    `json:"url"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (c *Client) GetCloudOrg(org string) (CloudOrg, error) {
+	resp := CloudOrg{}
+	err := c.request("GET", fmt.Sprintf("/api/orgs/%s", org), nil, nil, &resp)
+	return resp, err
+}


### PR DESCRIPTION
This will be needed to fetch the cloud org's ID from its name

I left the cloud org `replace` statement in the TF provider 🤦: https://github.com/grafana/terraform-provider-grafana/blob/master/go.mod#L6