### PR TITLE
auth: Make `expires_at` field optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Contributions to this library offering support for the [Terraform provider for G
 To run the tests:
 
 ```
-go test
+make test
 ```

--- a/cloud_access_policy_token.go
+++ b/cloud_access_policy_token.go
@@ -9,10 +9,10 @@ import (
 )
 
 type CreateCloudAccessPolicyTokenInput struct {
-	AccessPolicyID string    `json:"accessPolicyId"`
-	Name           string    `json:"name"`
-	DisplayName    string    `json:"displayName"`
-	ExpiresAt      time.Time `json:"expiresAt"`
+	AccessPolicyID string     `json:"accessPolicyId"`
+	Name           string     `json:"name"`
+	DisplayName    string     `json:"displayName,omitempty"`
+	ExpiresAt      *time.Time `json:"expiresAt,omitempty"`
 }
 
 type UpdateCloudAccessPolicyTokenInput struct {
@@ -20,14 +20,14 @@ type UpdateCloudAccessPolicyTokenInput struct {
 }
 
 type CloudAccessPolicyToken struct {
-	ID             string    `json:"id"`
-	AccessPolicyID string    `json:"accessPolicyId"`
-	Name           string    `json:"name"`
-	DisplayName    string    `json:"displayName"`
-	ExpiresAt      time.Time `json:"expiresAt"`
-	FirstUsedAt    time.Time `json:"firstUsedAt"`
-	CreatedAt      time.Time `json:"createdAt"`
-	UpdatedAt      time.Time `json:"updatedAt"`
+	ID             string     `json:"id"`
+	AccessPolicyID string     `json:"accessPolicyId"`
+	Name           string     `json:"name"`
+	DisplayName    string     `json:"displayName"`
+	ExpiresAt      *time.Time `json:"expiresAt"`
+	FirstUsedAt    time.Time  `json:"firstUsedAt"`
+	CreatedAt      time.Time  `json:"createdAt"`
+	UpdatedAt      *time.Time `json:"updatedAt"`
 
 	Token string `json:"token,omitempty"` // Only returned when creating a token.
 }


### PR DESCRIPTION
In response to https://github.com/grafana/support-escalations/issues/4823, this PR updates the `CreateCloudAccessPolicyTokenInput` and `CloudAccessPolicyToken` structs to reflect the fact that the `expires_at` field is optional. 