### PR TITLE
Fixed folder pagination

### DIFF
--- a/folder.go
+++ b/folder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 )
 
 // Folder represents a Grafana folder.
@@ -22,13 +23,28 @@ type FolderPayload struct {
 
 // Folders fetches and returns Grafana folders.
 func (c *Client) Folders() ([]Folder, error) {
-	folders := make([]Folder, 0)
-	err := c.request("GET", "/api/folders/", nil, nil, &folders)
-	if err != nil {
-		return folders, err
-	}
+	const limit = 1000
+	var (
+		page       = 0
+		newFolders []Folder
+		folders    []Folder
+		query      = make(url.Values)
+	)
+	query.Set("limit", fmt.Sprint(limit))
+	for {
+		page++
+		query.Set("page", fmt.Sprint(page))
 
-	return folders, err
+		if err := c.request("GET", "/api/folders/", query, nil, &newFolders); err != nil {
+			return nil, err
+		}
+
+		folders = append(folders, newFolders...)
+
+		if len(newFolders) < limit {
+			return folders, nil
+		}
+	}
 }
 
 // Folder fetches and returns the Grafana folder whose ID it's passed.


### PR DESCRIPTION
This MR offers support to the terraform provider for Grafana for folder search. Currently a folder search does not include results beyond 1000 items since the pagination was not in place.