### PR TITLE
Remove error about using API key and org

### DIFF
--- a/client.go
+++ b/client.go
@@ -160,12 +160,11 @@ func (c *Client) newRequest(method, requestPath string, query url.Values, body i
 		return req, err
 	}
 
+	// cannot use both API key and org ID. API keys are scoped to single org
 	if c.config.APIKey != "" {
-		if c.config.OrgID != 0 {
-			return req, fmt.Errorf("cannot use both API key and org ID. API keys are scoped to single org")
-		}
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.config.APIKey))
-	} else if c.config.OrgID != 0 {
+	}
+	if c.config.OrgID != 0 {
 		req.Header.Add("X-Grafana-Org-Id", strconv.FormatInt(c.config.OrgID, 10))
 	}
 


### PR DESCRIPTION
This will simplify code in the provider. 
In some cases, we obtain the OrgID from the API and send it back on every request, regardless of auth