### PR TITLE
Dashboard: Get folder UID from reads

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -12,6 +12,7 @@ type DashboardMeta struct {
 	IsStarred bool   `json:"isStarred"`
 	Slug      string `json:"slug"`
 	Folder    int64  `json:"folderId"`
+	FolderUID int64  `json:"folderUid"`
 	URL       string `json:"url"`
 }
 
@@ -26,14 +27,14 @@ type DashboardSaveResponse struct {
 
 // Dashboard represents a Grafana dashboard.
 type Dashboard struct {
-	Meta      DashboardMeta          `json:"meta"`
-	Model     map[string]interface{} `json:"dashboard"`
-	FolderID  int64                  `json:"folderId"`
-	FolderUID string                 `json:"folderUid"`
-	Overwrite bool                   `json:"overwrite"`
+	Meta     DashboardMeta          `json:"meta"`
+	Model    map[string]interface{} `json:"dashboard"`
+	FolderID int64                  `json:"folderId"`
 
-	// This is only used when creating a new dashboard, it will always be empty when getting a dashboard.
-	Message string `json:"message"`
+	// These fields are only used when creating a new dashboard, they will always be empty when getting a dashboard.
+	Overwrite bool   `json:"overwrite,omitempty"`
+	Message   string `json:"message,omitempty"`
+	FolderUID string `json:"folderUid,omitempty"`
 }
 
 // SaveDashboard is a deprecated method for saving a Grafana dashboard. Use NewDashboard.


### PR DESCRIPTION
It's easier to manage folders with UIDs than IDs. This will be used to add that functionality to the Terraform provider