### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday


### PR DESCRIPTION
There's a push in our org (gops) to ensure that dependabot is enabled on code we own.

I noticed we have it in the TF provider, but not here, so this PR turns on dependabot.
I expect this to upgrade very rarely, as this repo only has two dependencies, but it's nice to have. I set up for weekly evaluations on mondays.

contrib https://github.com/grafana/alerting-squad/issues/489