### PR TITLE
Add datasource caching API

### DIFF
--- a/datasource_cache.go
+++ b/datasource_cache.go
@@ -1,0 +1,72 @@
+package gapi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type DatasourceCache struct {
+	Message        string `json:"message"`
+	DatasourceID   int64  `json:"dataSourceID"`
+	DatasourceUID  string `json:"dataSourceUID"`
+	Enabled        bool   `json:"enabled"`
+	TTLQueriesMs   int64  `json:"ttlQueriesMs"`
+	TTLResourcesMs int64  `json:"ttlResourcesMs"`
+	UseDefaultTLS  bool   `json:"useDefaultTTL"`
+	DefaultTTLMs   int64  `json:"defaultTTLMs"`
+	Created        string `json:"created"`
+	Updated        string `json:"updated"`
+}
+
+type DatasourceCachePayload struct {
+	DatasourceID   int64  `json:"dataSourceID"`
+	DatasourceUID  string `json:"dataSourceUID"`
+	Enabled        bool   `json:"enabled"`
+	UseDefaultTLS  bool   `json:"useDefaultTTL"`
+	TTLQueriesMs   int64  `json:"ttlQueriesMs"`
+	TTLResourcesMs int64  `json:"ttlResourcesMs"`
+}
+
+// EnableDatasourceCache enables the datasource cache (this is a datasource setting)
+func (c *Client) EnableDatasourceCache(id int64) error {
+	path := fmt.Sprintf("/api/datasources/%d/cache/enable", id)
+	if err := c.request("POST", path, nil, nil, nil); err != nil {
+		return fmt.Errorf("error enabling cache at %s: %w", path, err)
+	}
+	return nil
+}
+
+// DisableDatasourceCache disables the datasource cache (this is a datasource setting)
+func (c *Client) DisableDatasourceCache(id int64) error {
+	path := fmt.Sprintf("/api/datasources/%d/cache/disable", id)
+	if err := c.request("POST", path, nil, nil, nil); err != nil {
+		return fmt.Errorf("error disabling cache at %s: %w", path, err)
+	}
+	return nil
+}
+
+// UpdateDatasourceCache updates the cache configurations
+func (c *Client) UpdateDatasourceCache(id int64, payload *DatasourceCachePayload) error {
+	path := fmt.Sprintf("/api/datasources/%d/cache", id)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal err: %w", err)
+	}
+
+	if err = c.request("POST", path, nil, data, nil); err != nil {
+		return fmt.Errorf("error updating cache at %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// DatasourceCache fetches datasource cache configuration
+func (c *Client) DatasourceCache(id int64) (*DatasourceCache, error) {
+	path := fmt.Sprintf("/api/datasources/%d/cache", id)
+	cache := &DatasourceCache{}
+	err := c.request("GET", path, nil, nil, cache)
+	if err != nil {
+		return cache, fmt.Errorf("error getting cache at %s: %w", path, err)
+	}
+	return cache, nil
+}

--- a/datasource_cache_test.go
+++ b/datasource_cache_test.go
@@ -1,0 +1,84 @@
+package gapi
+
+import (
+	"testing"
+
+	"github.com/gobs/pretty"
+)
+
+const (
+	getDatasourceCacheJSON = `
+	{
+		"message": "Data source cache settings loaded",
+		"dataSourceID": 1,
+		"dataSourceUID": "jZrmlLCGka",
+		"enabled": true,
+		"useDefaultTTL": false,
+		"ttlQueriesMs": 60000,
+		"ttlResourcesMs": 300000,
+		"defaultTTLMs": 300000,
+		"created": "2023-04-21T11:49:22-04:00",
+		"updated": "2023-04-24T17:03:40-04:00"
+	}`
+	updateDatasourceCacheJSON = `
+	{
+		"message": "Data source cache settings updated",
+		"dataSourceID": 1,
+		"dataSourceUID": "jZrmlLCGka",
+		"enabled": true,
+		"useDefaultTTL": false,
+		"ttlQueriesMs": 60000,
+		"ttlResourcesMs": 300000,
+		"defaultTTLMs": 300000,
+		"created": "2023-04-21T11:49:22-04:00",
+		"updated": "2023-04-24T17:03:40-04:00"
+ 	}`
+)
+
+func TestDatasourceCache(t *testing.T) {
+	client := gapiTestTools(t, 200, getDatasourceCacheJSON)
+	resp, err := client.DatasourceCache(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(pretty.PrettyFormat(resp))
+
+	expects := DatasourceCache{
+		Message:        "Data source cache settings loaded",
+		DatasourceID:   1,
+		DatasourceUID:  "jZrmlLCGka",
+		Enabled:        true,
+		UseDefaultTLS:  false,
+		TTLQueriesMs:   60000,
+		TTLResourcesMs: 300000,
+		DefaultTTLMs:   300000,
+		Created:        "2023-04-21T11:49:22-04:00",
+		Updated:        "2023-04-24T17:03:40-04:00",
+	}
+
+	if resp.Enabled != expects.Enabled ||
+		resp.DatasourceUID != expects.DatasourceUID ||
+		resp.UseDefaultTLS != expects.UseDefaultTLS ||
+		resp.TTLQueriesMs != expects.TTLQueriesMs ||
+		resp.TTLResourcesMs != expects.TTLResourcesMs ||
+		resp.DefaultTTLMs != expects.DefaultTTLMs {
+		t.Error("Not correctly parsing returned datasource cache")
+	}
+}
+
+func TestUpdateDatasourceCache(t *testing.T) {
+	client := gapiTestTools(t, 200, updateDatasourceCacheJSON)
+	payload := &DatasourceCachePayload{
+		DatasourceID:   1,
+		DatasourceUID:  "jZrmlLCGka",
+		Enabled:        true,
+		UseDefaultTLS:  true,
+		TTLQueriesMs:   6000,
+		TTLResourcesMs: 30000,
+	}
+	err := client.UpdateDatasourceCache(1, payload)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Adding support for the [datasource caching API](https://grafana.com/docs/grafana/latest/developers/http_api/query_and_resource_caching/).

This is needed to enable support for [the terraform provider](https://github.com/grafana/terraform-provider-grafana/issues/765)