### PR TITLE
Add a method to get current user details

### DIFF
--- a/user.go
+++ b/user.go
@@ -68,6 +68,12 @@ func (c *Client) User(id int64) (user User, err error) {
 	return
 }
 
+// CurrentUser fetches details of the currently logged user
+func (c *Client) CurrentUser() (user User, err error) {
+	err = c.request("GET", "/api/user", nil, nil, &user)
+	return
+}
+
 // UserByEmail fetches a user by email address.
 func (c *Client) UserByEmail(email string) (user User, err error) {
 	query := url.Values{}

--- a/user_test.go
+++ b/user_test.go
@@ -56,6 +56,23 @@ func TestUser(t *testing.T) {
 	}
 }
 
+func TestCurrentUser(t *testing.T) {
+	client := gapiTestTools(t, 200, getUserJSON)
+
+	user, err := client.CurrentUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(pretty.PrettyFormat(user))
+
+	if user.Email != "user@localhost" ||
+		user.ID != 2 ||
+		user.IsAdmin != false {
+		t.Error("Not correctly parsing returned user.")
+	}
+}
+
 func TestUserByEmail(t *testing.T) {
 	client := gapiTestTools(t, 200, getUserByEmailJSON)
 


### PR DESCRIPTION
Hi,
I noticed there is no method to get current user from the Grafana API (accessible via /api/user)
I think it is pretty straightforward.
I had some strange golangci-lint errors when running `make test`, on files I did not change. I assumed it was because of different versions of golangci-lint Let me know if I need to look into it anyway.
wuzuf