### PR TITLE
fix connection leak

### DIFF
--- a/client.go
+++ b/client.go
@@ -113,7 +113,7 @@ func (c *Client) request(method, requestPath string, query url.Values, body []by
 
 		// read the body (even on non-successful HTTP status codes), as that's what the unit tests expect
 		bodyContents, err = ioutil.ReadAll(resp.Body)
-		_ = resp.Body.Close()
+		resp.Body.Close() //nolint:errcheck
 
 		// if there was an error reading the body, try again
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -111,10 +111,9 @@ func (c *Client) request(method, requestPath string, query url.Values, body []by
 			continue
 		}
 
-		defer resp.Body.Close()
-
 		// read the body (even on non-successful HTTP status codes), as that's what the unit tests expect
 		bodyContents, err = ioutil.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 
 		// if there was an error reading the body, try again
 		if err != nil {


### PR DESCRIPTION
We got a lot of established connections(over 20,000) when using [grafana-operator](https://github.com/grafana-operator/grafana-operator) depends on this library and the leak made the operator couldn't visit grafana anymore.