### PR TITLE
Typed error for Not Found (404) responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -141,7 +141,6 @@ func (c *Client) request(method, requestPath string, query url.Values, body []by
 	switch {
 	case resp.StatusCode == http.StatusNotFound:
 		return ErrNotFound{
-			StatusCode:   resp.StatusCode,
 			BodyContents: bodyContents,
 		}
 	case resp.StatusCode >= 400:

--- a/client.go
+++ b/client.go
@@ -138,7 +138,13 @@ func (c *Client) request(method, requestPath string, query url.Values, body []by
 	}
 
 	// check status code.
-	if resp.StatusCode >= 400 {
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return ErrNotFound{
+			StatusCode:   resp.StatusCode,
+			BodyContents: bodyContents,
+		}
+	case resp.StatusCode >= 400:
 		return fmt.Errorf("status: %d, body: %v", resp.StatusCode, string(bodyContents))
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -3,10 +3,9 @@ package gapi
 import "fmt"
 
 type ErrNotFound struct {
-	StatusCode   int
 	BodyContents []byte
 }
 
 func (e ErrNotFound) Error() string {
-	return fmt.Sprintf("status: %d, body: %v", e.StatusCode, string(e.BodyContents))
+	return fmt.Sprintf("status: 404, body: %s", e.BodyContents)
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,12 @@
+package gapi
+
+import "fmt"
+
+type ErrNotFound struct {
+	StatusCode   int
+	BodyContents []byte
+}
+
+func (e ErrNotFound) Error() string {
+	return fmt.Sprintf("status: %d, body: %v", e.StatusCode, string(e.BodyContents))
+}


### PR DESCRIPTION
From the library's consumer point of view, the error for all HTTP responses where _status code is >= 400_ look the same. However, certain errors, like Not Found (404) require specific error handling (for instance, from [Grizzly](https://github.com/grafana/grizzly)), and with the current approach that would require parsing the error message (_bad idea!_).

So, here I suggest to create a typed error for this specific case. We can add more typed errors later, if needed.

I don't think exposing this will hurt, but if there's any concern, I'd be happy to expose it as a behavioral error.

```go
type errNotFound interface {
        NotFound() bool
}
 
// IsErrNotFound returns true if err is not found.
func IsErrNotFound(err error) bool {
        nf, ok := err.(errNotFound)
        return ok && nf.NotFound()
}
```

Thanks!