### PR TITLE
Retrieve data source by name

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -95,6 +95,18 @@ func (c *Client) DataSourceByUID(uid string) (*DataSource, error) {
 	return result, err
 }
 
+// DataSourceByName fetches and returns the Grafana data source whose name is passed.
+func (c *Client) DataSourceByName(name string) (*DataSource, error) {
+	path := fmt.Sprintf("/api/datasources/name/%s", name)
+	result := &DataSource{}
+	err := c.request("GET", path, nil, nil, result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, err
+}
+
 // DataSourceIDByName returns the Grafana data source ID by name.
 func (c *Client) DataSourceIDByName(name string) (int64, error) {
 	path := fmt.Sprintf("/api/datasources/id/%s", name)


### PR DESCRIPTION
The client does not have support (yet) to [get a single data source by name](https://grafana.com/docs/grafana/latest/developers/http_api/data_source/#get-a-single-data-source-by-name).

So, this adds such support, in a very similar way the `DataSourceByUID` works now for uids.

PS: I was about to re-use the new method for `DataSourceIDByName`, but apparently that method is using a different endpoint (`/api/datasources/id/`, not `/api/datasources/name/`).