### PR TITLE
Add data source missing fields

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -14,7 +14,7 @@ type DataSource struct {
 
 	Type string `json:"type"`
 	// This is only returned by the API. It depends on the Type.
-	TypeLogoUrl string `json:"typeLogoUrl,omitempty"`
+	TypeLogoURL string `json:"typeLogoUrl,omitempty"`
 
 	URL    string `json:"url"`
 	Access string `json:"access"`

--- a/datasource.go
+++ b/datasource.go
@@ -8,10 +8,14 @@ import (
 
 // DataSource represents a Grafana data source.
 type DataSource struct {
-	ID     int64  `json:"id,omitempty"`
-	UID    string `json:"uid,omitempty"`
-	Name   string `json:"name"`
-	Type   string `json:"type"`
+	ID   int64  `json:"id,omitempty"`
+	UID  string `json:"uid,omitempty"`
+	Name string `json:"name"`
+
+	Type string `json:"type"`
+	// This is only returned by the API. It depends on the Type.
+	TypeLogoUrl string `json:"typeLogoUrl,omitempty"`
+
 	URL    string `json:"url"`
 	Access string `json:"access"`
 
@@ -27,8 +31,12 @@ type DataSource struct {
 	BasicAuth     bool   `json:"basicAuth"`
 	BasicAuthUser string `json:"basicAuthUser,omitempty"`
 
+	WithCredentials bool `json:"withCredentials,omitempty"`
+
 	JSONData       map[string]interface{} `json:"jsonData,omitempty"`
 	SecureJSONData map[string]interface{} `json:"secureJsonData,omitempty"`
+
+	Version int `json:"version,omitempty"`
 }
 
 // NewDataSource creates a new Grafana data source.


### PR DESCRIPTION
It adds a few more fields into the DataSource definition:
- TypeLogoUrl
- WithCredentials
- Version

These are currently supported by the Grafana API ([spec](https://github.com/grafana/grafana/blob/main/public/api-merged.json#L13031)).