### PR TITLE
Updates SLO types

### DIFF
--- a/slo.go
+++ b/slo.go
@@ -12,6 +12,7 @@ type Slos struct {
 	Slos []Slo `json:"slos"`
 }
 
+// Defines values for QueryType.
 const (
 	QueryTypeFreeform  QueryType = "freeform"
 	QueryTypeHistogram QueryType = "histogram"
@@ -19,6 +20,18 @@ const (
 	QueryTypeThreshold QueryType = "threshold"
 )
 
+// Defines values for StatusType.
+const (
+	StatusTypeCreated  StatusType = "created"
+	StatusTypeCreating StatusType = "creating"
+	StatusTypeDeleting StatusType = "deleting"
+	StatusTypeError    StatusType = "error"
+	StatusTypeUnknown  StatusType = "unknown"
+	StatusTypeUpdated  StatusType = "updated"
+	StatusTypeUpdating StatusType = "updating"
+)
+
+// Defines values for ThresholdOperator.
 const (
 	ThresholdOperatorEmpty      ThresholdOperator = "<"
 	ThresholdOperatorEqualEqual ThresholdOperator = "=="
@@ -27,6 +40,7 @@ const (
 	ThresholdOperatorN3         ThresholdOperator = ">"
 )
 
+// Alerting defines model for Alerting.
 type Alerting struct {
 	Annotations []Label           `json:"annotations,omitempty"`
 	FastBurn    *AlertingMetadata `json:"fastBurn,omitempty"`
@@ -34,19 +48,29 @@ type Alerting struct {
 	SlowBurn    *AlertingMetadata `json:"slowBurn,omitempty"`
 }
 
+// AlertingMetadata defines model for AlertingMetadata.
 type AlertingMetadata struct {
 	Annotations []Label `json:"annotations,omitempty"`
 	Labels      []Label `json:"labels,omitempty"`
 }
 
+// DashboardRef defines model for DashboardRef.
 type DashboardRef struct {
 	UID string `json:"UID"`
 }
 
+// DestinationDatasource defines model for DestinationDatasource.
+type DestinationDatasource struct {
+	Type *string `json:"type,omitempty"`
+	Uid  *string `json:"uid,omitempty"`
+}
+
+// FreeformQuery defines model for FreeformQuery.
 type FreeformQuery struct {
 	Query string `json:"query"`
 }
 
+// HistogramQuery defines model for HistogramQuery.
 type HistogramQuery struct {
 	GroupByLabels []string  `json:"groupByLabels,omitempty"`
 	Metric        MetricDef `json:"metric"`
@@ -54,21 +78,25 @@ type HistogramQuery struct {
 	Threshold     Threshold `json:"threshold"`
 }
 
+// Label defines model for Label.
 type Label struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
+// MetricDef defines model for MetricDef.
 type MetricDef struct {
 	PrometheusMetric string  `json:"prometheusMetric"`
 	Type             *string `json:"type,omitempty"`
 }
 
+// Objective defines model for Objective.
 type Objective struct {
 	Value  float64 `json:"value"`
 	Window string  `json:"window"`
 }
 
+// Query defines model for Query.
 type Query struct {
 	Freeform  *FreeformQuery  `json:"freeform,omitempty"`
 	Histogram *HistogramQuery `json:"histogram,omitempty"`
@@ -77,32 +105,55 @@ type Query struct {
 	Type      QueryType       `json:"type"`
 }
 
+// QueryType defines model for Query.Type.
 type QueryType string
 
+// RatioQuery defines model for RatioQuery.
 type RatioQuery struct {
 	GroupByLabels []string  `json:"groupByLabels,omitempty"`
 	SuccessMetric MetricDef `json:"successMetric"`
 	TotalMetric   MetricDef `json:"totalMetric"`
 }
 
-type Slo struct {
-	Alerting              *Alerting     `json:"alerting,omitempty"`
-	Description           string        `json:"description"`
+// ReadOnly defines model for ReadOnly.
+type ReadOnly struct {
 	DrillDownDashboardRef *DashboardRef `json:"drillDownDashboardRef,omitempty"`
-	Labels                []Label       `json:"labels,omitempty"`
-	Name                  string        `json:"name"`
-	Objectives            []Objective   `json:"objectives"`
-	Query                 Query         `json:"query"`
-	UUID                  string        `json:"uuid"`
+	Provenance            *string       `json:"provenance,omitempty"`
+	Status                *Status       `json:"status,omitempty"`
 }
 
+// Slo defines model for Slo.
+type Slo struct {
+	Alerting              *Alerting              `json:"alerting,omitempty"`
+	Description           string                 `json:"description"`
+	DestinationDatasource *DestinationDatasource `json:"destinationDatasource,omitempty"`
+	Labels                []Label                `json:"labels,omitempty"`
+	Name                  string                 `json:"name"`
+	Objectives            []Objective            `json:"objectives"`
+	Query                 Query                  `json:"query"`
+	ReadOnly              *ReadOnly              `json:"readOnly,omitempty"`
+	Uuid                  string                 `json:"uuid"`
+}
+
+// Status defines model for Status.
+type Status struct {
+	Message *string    `json:"message,omitempty"`
+	Type    StatusType `json:"type"`
+}
+
+// StatusType defines model for Status.Type.
+type StatusType string
+
+// Threshold defines model for Threshold.
 type Threshold struct {
 	Operator ThresholdOperator `json:"operator"`
 	Value    float64           `json:"value"`
 }
 
+// ThresholdOperator defines model for Threshold.Operator.
 type ThresholdOperator string
 
+// ThresholdQuery defines model for ThresholdQuery.
 type ThresholdQuery struct {
 	GroupByLabels []string  `json:"groupByLabels,omitempty"`
 	Metric        MetricDef `json:"metric"`

--- a/slo.go
+++ b/slo.go
@@ -20,17 +20,6 @@ const (
 	QueryTypeThreshold QueryType = "threshold"
 )
 
-// Defines values for StatusType.
-const (
-	StatusTypeCreated  StatusType = "created"
-	StatusTypeCreating StatusType = "creating"
-	StatusTypeDeleting StatusType = "deleting"
-	StatusTypeError    StatusType = "error"
-	StatusTypeUnknown  StatusType = "unknown"
-	StatusTypeUpdated  StatusType = "updated"
-	StatusTypeUpdating StatusType = "updating"
-)
-
 // Defines values for ThresholdOperator.
 const (
 	ThresholdOperatorEmpty      ThresholdOperator = "<"
@@ -61,8 +50,8 @@ type DashboardRef struct {
 
 // DestinationDatasource defines model for DestinationDatasource.
 type DestinationDatasource struct {
-	Type *string `json:"type,omitempty"`
-	UID  *string `json:"uid,omitempty"`
+	Type string `json:"type,omitempty"`
+	UID  string `json:"uid,omitempty"`
 }
 
 // FreeformQuery defines model for FreeformQuery.
@@ -86,8 +75,8 @@ type Label struct {
 
 // MetricDef defines model for MetricDef.
 type MetricDef struct {
-	PrometheusMetric string  `json:"prometheusMetric"`
-	Type             *string `json:"type,omitempty"`
+	PrometheusMetric string `json:"prometheusMetric"`
+	Type             string `json:"type,omitempty"`
 }
 
 // Objective defines model for Objective.
@@ -118,7 +107,7 @@ type RatioQuery struct {
 // ReadOnly defines model for ReadOnly.
 type ReadOnly struct {
 	DrillDownDashboardRef *DashboardRef `json:"drillDownDashboardRef,omitempty"`
-	Provenance            *string       `json:"provenance,omitempty"`
+	Provenance            string        `json:"provenance,omitempty"`
 	Status                *Status       `json:"status,omitempty"`
 }
 
@@ -137,12 +126,9 @@ type Slo struct {
 
 // Status defines model for Status.
 type Status struct {
-	Message *string    `json:"message,omitempty"`
-	Type    StatusType `json:"type"`
+	Message string `json:"message,omitempty"`
+	Type    string `json:"type"`
 }
-
-// StatusType defines model for Status.Type.
-type StatusType string
 
 // Threshold defines model for Threshold.
 type Threshold struct {

--- a/slo.go
+++ b/slo.go
@@ -62,7 +62,7 @@ type DashboardRef struct {
 // DestinationDatasource defines model for DestinationDatasource.
 type DestinationDatasource struct {
 	Type *string `json:"type,omitempty"`
-	Uid  *string `json:"uid,omitempty"`
+	UID  *string `json:"uid,omitempty"`
 }
 
 // FreeformQuery defines model for FreeformQuery.
@@ -132,7 +132,7 @@ type Slo struct {
 	Objectives            []Objective            `json:"objectives"`
 	Query                 Query                  `json:"query"`
 	ReadOnly              *ReadOnly              `json:"readOnly,omitempty"`
-	Uuid                  string                 `json:"uuid"`
+	UUID                  string                 `json:"uuid"`
 }
 
 // Status defines model for Status.

--- a/slo_test.go
+++ b/slo_test.go
@@ -35,8 +35,8 @@ func TestSLOs(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if slo.UUID != "qkkrknp12w6tmsdcrfkdf" {
-			t.Errorf("incorrect UID - expected qkkrknp12w6tmsdcrfkdf, got %s", slo.UUID)
+		if slo.Uuid != "qkkrknp12w6tmsdcrfkdf" {
+			t.Errorf("incorrect UID - expected qkkrknp12w6tmsdcrfkdf, got %s", slo.Uuid)
 		}
 	})
 
@@ -70,7 +70,7 @@ func TestSLOs(t *testing.T) {
 		slo := generateSlo()
 		slo.Description = "Updated Description"
 
-		err := client.UpdateSlo(slo.UUID, slo)
+		err := client.UpdateSlo(slo.Uuid, slo)
 
 		if err != nil {
 			t.Error(err)

--- a/slo_test.go
+++ b/slo_test.go
@@ -35,8 +35,8 @@ func TestSLOs(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if slo.Uuid != "qkkrknp12w6tmsdcrfkdf" {
-			t.Errorf("incorrect UID - expected qkkrknp12w6tmsdcrfkdf, got %s", slo.Uuid)
+		if slo.UUID != "qkkrknp12w6tmsdcrfkdf" {
+			t.Errorf("incorrect UID - expected qkkrknp12w6tmsdcrfkdf, got %s", slo.UUID)
 		}
 	})
 
@@ -70,7 +70,7 @@ func TestSLOs(t *testing.T) {
 		slo := generateSlo()
 		slo.Description = "Updated Description"
 
-		err := client.UpdateSlo(slo.Uuid, slo)
+		err := client.UpdateSlo(slo.UUID, slo)
 
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
Updates SLO Types in GAPI to prepare for changes to the Grafana Terraform Provider to support the Destination Datasource field on the SLO 

Note: The tests within GAPI fail if I used `Uid` or `Uuid` - so I had to change all the type fields to be UUID / UID respectively. 