### PR TITLE
Add omitempty to Preferences theme

### DIFF
--- a/preferences.go
+++ b/preferences.go
@@ -20,7 +20,7 @@ type QueryHistoryPreference struct {
 
 // Preferences represents Grafana preferences.
 type Preferences struct {
-	Theme            string                 `json:"theme"`
+	Theme            string                 `json:"theme,omitempty"`
 	HomeDashboardID  int64                  `json:"homeDashboardId,omitempty"`
 	HomeDashboardUID string                 `json:"homeDashboardUID,omitempty"`
 	Timezone         string                 `json:"timezone,omitempty"`


### PR DESCRIPTION
Right now, the `theme` attribute from `Preferences` does not have `omitempty`. That way, whenever it gets marshaled to JSON, the JSON body receives a `"theme": ""`. 

This makes it impossible to use the Grafana Preferences PATCH endpoint without specifying/updating `theme` because Grafana validates if the given theme is valid, as it is not null:
https://github.com/grafana/grafana/blob/1d38edc483570e4767a6ef1800dfdc1b576838c1/pkg/api/preferences.go#L124-L127